### PR TITLE
feat: 유저 조회 전용 응용서비스 생성

### DIFF
--- a/src/main/java/com/map/gaja/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/map/gaja/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.map.gaja.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.ArrayList;
 import java.util.List;
 
+@Order(2)
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {

--- a/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
+++ b/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
@@ -1,0 +1,14 @@
+package com.map.gaja.user.application;
+
+import com.map.gaja.user.domain.exception.UserNotFoundException;
+import com.map.gaja.user.domain.model.User;
+import com.map.gaja.user.infrastructure.UserRepository;
+
+public final class UserServiceHelper {
+    public static User findExistingUser(UserRepository userRepository, String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    throw new UserNotFoundException();
+                });
+    }
+}

--- a/src/main/java/com/map/gaja/user/domain/exception/UserNotFoundException.java
+++ b/src/main/java/com/map/gaja/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,12 @@
+package com.map.gaja.user.domain.exception;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@NoArgsConstructor
+@Getter
+public class UserNotFoundException extends RuntimeException{
+    private final String message = "사용자를 찾을 수 없습니다.";
+    private final HttpStatus status = HttpStatus.NOT_FOUND;
+}

--- a/src/main/java/com/map/gaja/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/map/gaja/user/infrastructure/UserRepository.java
@@ -1,0 +1,10 @@
+package com.map.gaja.user.infrastructure;
+
+import com.map.gaja.user.domain.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/map/gaja/user/presentation/dto/response/NotFoundResponse.java
+++ b/src/main/java/com/map/gaja/user/presentation/dto/response/NotFoundResponse.java
@@ -1,0 +1,10 @@
+package com.map.gaja.user.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NotFoundResponse {
+    private String message;
+}

--- a/src/main/java/com/map/gaja/user/presentation/exception/UserExceptionHandler.java
+++ b/src/main/java/com/map/gaja/user/presentation/exception/UserExceptionHandler.java
@@ -2,10 +2,12 @@ package com.map.gaja.user.presentation.exception;
 
 import com.map.gaja.user.domain.exception.UserNotFoundException;
 import com.map.gaja.user.presentation.dto.response.NotFoundResponse;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Order(1)
 @RestControllerAdvice(basePackages = "com.map.gaja.user.presentation.api")
 public class UserExceptionHandler {
 

--- a/src/main/java/com/map/gaja/user/presentation/exception/UserExceptionHandler.java
+++ b/src/main/java/com/map/gaja/user/presentation/exception/UserExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.map.gaja.user.presentation.exception;
+
+import com.map.gaja.user.domain.exception.UserNotFoundException;
+import com.map.gaja.user.presentation.dto.response.NotFoundResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.map.gaja.user.presentation.api")
+public class UserExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<NotFoundResponse> handleUserNotFound(UserNotFoundException e) {
+        return new ResponseEntity<>(
+                new NotFoundResponse(e.getMessage()), e.getStatus()
+        );
+    }
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #16 

<!--
 전달할 내용
-->
## comment
- UserNotFoundException이 UserExceptionHandler를  실행하는 것이 아닌 GlobalExceptionHandler클래스에 있는 @ExceptionHandler(Exception.class)가 먼저 실행되는 문제를 @Order사용해서 처리기 우선순위를 지정해줬음
- RuntimeException을 상속받은 UserNotFoundException.class 필드를 상수로 초기값을 미리 줬는데 저 부분 괜찮?

<!--
 참고한 사이트
-->
## References
- 