### PR TITLE
Feat/#32 ST_Distance_Sphere MySQL Dialect에 추가

### DIFF
--- a/src/main/java/com/map/gaja/client/infrastructure/repository/querydsl/ClientRepositoryCustomImpl.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/querydsl/ClientRepositoryCustomImpl.java
@@ -32,7 +32,7 @@ public class ClientRepositoryCustomImpl implements ClientRepositoryCustom {
                                 client.phoneNumber,
                                 getAddressDto(),
                                 getLocationDto(),
-                                Expressions.asNumber(1d) // 임시 distance
+                                getLocationDistance(locationSearchCond) // 좌표 정보가 없다면 -1을 반환함
                         )
                 )
                 .from(client)
@@ -48,6 +48,14 @@ public class ClientRepositoryCustomImpl implements ClientRepositoryCustom {
         }
 
         return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    private NumberExpression<Double> getLocationDistance(NearbyClientSearchRequest locationSearchCond) {
+        if(isLocationSearchCondEmpty(locationSearchCond)) {
+            return Expressions.asNumber(-1.0);
+        }
+
+        return getCalcDistanceNativeSQL(locationSearchCond.getLocation());
     }
 
     private static ConstructorExpression<LocationDto> getLocationDto() {

--- a/src/main/java/com/map/gaja/global/config/MySQLCustomDialect.java
+++ b/src/main/java/com/map/gaja/global/config/MySQLCustomDialect.java
@@ -1,0 +1,12 @@
+package com.map.gaja.global.config;
+
+import org.hibernate.dialect.MySQL57Dialect;
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MySQLCustomDialect extends MySQL57Dialect {
+    public MySQLCustomDialect() {
+        super();
+        this.registerFunction("ST_Distance_Sphere",new StandardSQLFunction("ST_Distance_Sphere", StandardBasicTypes.DOUBLE));
+    }
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #32 

<!--
 전달할 내용
-->
## comment
- 이거 적용하려면 다음 설정이 있어야 함
```yml
spring:
  jpa:
    properties:
      hibernate:
        dialect: com.map.gaja.global.config.MySQLCustomDialect
```
- OAuth 관련 설정빼고 `application.yml`에 로컬 환경 설정만 Git에 등록할 수 있게 만들 수 있을 듯 따로 이슈만듦

<!--
 참고한 사이트
-->
## References
- Native 쿼리를 쓰는거라 글로 정리해봄
https://velog.io/@sdsd0908/MySQLJPA-QueryDSL%EB%A1%9C-%EC%9D%B8%EA%B7%BC-%EC%9C%84%EC%B9%98-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EA%B2%80%EC%83%89%ED%95%B4%EB%B3%B4%EA%B8%B0#mysql-st_distance_sphere-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0