### PR TITLE
feat: 카카오 oauth 로그인

### DIFF
--- a/src/main/java/com/map/gaja/global/authentication/AuthenticationHandler.java
+++ b/src/main/java/com/map/gaja/global/authentication/AuthenticationHandler.java
@@ -1,0 +1,16 @@
+package com.map.gaja.global.authentication;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationHandler {
+    public void saveContext(String email, String authority) {
+        Authentication token = new AuthenticationToken(email, authority);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(token);
+        SecurityContextHolder.setContext(context);
+    }
+}

--- a/src/main/java/com/map/gaja/global/authentication/AuthenticationToken.java
+++ b/src/main/java/com/map/gaja/global/authentication/AuthenticationToken.java
@@ -1,0 +1,49 @@
+package com.map.gaja.global.authentication;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@AllArgsConstructor
+public class AuthenticationToken implements Authentication {
+    private final String email;
+    private final String authority;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(() -> authority);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return email;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
     private final AuthenticationHandler authenticationHandler;
 
     @Transactional
-    public void login(LoginRequest request) {
+    public Integer login(LoginRequest request) {
         String email = oauth2Client.getEmail(request.getAccessToken());
         if (email == null) { //카카오 로그인 실패
             throw new UserNotFoundException();
@@ -39,6 +39,7 @@ public class UserService {
 
         authenticationHandler.saveContext(email, user.getAuthority().toString()); //SecurityContextHolder에 인증 객체 저장
 
-        //기존 유저는 클라이언트 정보를 리턴해야함.
+        //번들 아이디로 응답해주면 클라이언트 쪽에서 번들을 가지고 고객조회 API를 호출한다. null이면 호출X
+        return user.getReferenceBundleId();
     }
 }

--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -1,0 +1,44 @@
+package com.map.gaja.user.application;
+
+import com.map.gaja.global.authentication.AuthenticationHandler;
+import com.map.gaja.user.domain.exception.UserNotFoundException;
+import com.map.gaja.user.domain.model.Authority;
+import com.map.gaja.user.domain.model.User;
+import com.map.gaja.user.infrastructure.Oauth2Client;
+import com.map.gaja.user.infrastructure.UserRepository;
+import com.map.gaja.user.presentation.dto.request.LoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final Oauth2Client oauth2Client;
+    private final UserRepository userRepository;
+    private final AuthenticationHandler authenticationHandler;
+
+    @Transactional
+    public void login(LoginRequest request) {
+        String email = oauth2Client.getEmail(request.getAccessToken());
+        if (email == null) { //카카오 로그인 실패
+            throw new UserNotFoundException();
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElse(User.builder()
+                        .email(email)
+                        .authority(Authority.FREE)
+                        .bundleCount(0)
+                        .createdDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                        .lastLoginDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                        .build());
+
+        authenticationHandler.saveContext(email, user.getAuthority().toString()); //SecurityContextHolder에 인증 객체 저장
+
+        //기존 유저는 클라이언트 정보를 리턴해야함.
+    }
+}

--- a/src/main/java/com/map/gaja/user/domain/model/User.java
+++ b/src/main/java/com/map/gaja/user/domain/model/User.java
@@ -35,6 +35,8 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime lastLoginDate;
 
+    private Integer referenceBundleId;
+
     public void checkCreateBundlePermission() {
         if (authority.getLimitCount() <= bundleCount) {
             throw new BundleLimitExceededException(authority.name(), authority.getLimitCount());

--- a/src/main/java/com/map/gaja/user/infrastructure/Oauth2Client.java
+++ b/src/main/java/com/map/gaja/user/infrastructure/Oauth2Client.java
@@ -1,0 +1,42 @@
+package com.map.gaja.user.infrastructure;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Component
+public class Oauth2Client {
+    private static final String KAKAO_OAUTH2_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_ACCESS_TOKEN_HEADER = "Authorization";
+    private static final String KAKAO_ACCESS_TOKEN_PREFIX = "Bearer ";
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public String getEmail(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(KAKAO_ACCESS_TOKEN_HEADER, KAKAO_ACCESS_TOKEN_PREFIX + accessToken);
+
+        RequestEntity<Void> request = new RequestEntity<>(headers, HttpMethod.GET, URI.create(KAKAO_OAUTH2_URL));
+        ResponseEntity<String> response = restTemplate.exchange(request, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            try {
+                JsonNode jsonNode = mapper.readTree(response.getBody());
+                return jsonNode.get("kakao_account").get("email").asText();
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/map/gaja/user/presentation/api/UserController.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/UserController.java
@@ -1,17 +1,42 @@
 package com.map.gaja.user.presentation.api;
 
+import com.map.gaja.user.application.UserService;
+import com.map.gaja.user.presentation.dto.request.LoginRequest;
 import com.map.gaja.user.presentation.dto.request.Req;
 import com.map.gaja.user.presentation.dto.response.Res;
 import com.map.gaja.user.presentation.api.specification.UserApiSpecification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user")
+@RequiredArgsConstructor
 public class UserController implements UserApiSpecification {
+    private final UserService userService;
 
     @Override
     @PostMapping("/test")
     public Res test(@RequestBody Req req) {
         return new Res(1L);
     }
+
+    @Override
+    @PostMapping("/login")
+    public ResponseEntity<Integer> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(userService.login(request));
+    }
+
+    @GetMapping("/hi")
+    public String hi(@AuthenticationPrincipal String email) {
+//        HttpSession session = request.getSession(false);
+//        System.out.println(session.getId());
+//        System.out.println(session.toString());
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        //session.invalidate();
+
+        return email;
+    }
+
 }

--- a/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
@@ -1,12 +1,14 @@
 package com.map.gaja.user.presentation.api.specification;
 
 import com.map.gaja.global.exception.ExceptionDto;
+import com.map.gaja.user.presentation.dto.request.LoginRequest;
 import com.map.gaja.user.presentation.dto.request.Req;
 import com.map.gaja.user.presentation.dto.response.Res;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
 
 public interface UserApiSpecification {
     @Operation(summary = "api 설명에 대한 간단 요약",
@@ -18,4 +20,13 @@ public interface UserApiSpecification {
             }
     )
     Res test(Req req);
+
+    @Operation(summary = "로그인 요청",
+            description = "카카오 액세스토큰을 이용한 로그인",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "최근에 참조한 번들아이디 => null이면 클라이언트 조회 api 호출X / null이 아닌 정수면 클라이언트 조회", content = @Content(schema = @Schema(implementation = Integer.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+            }
+    )
+    ResponseEntity<Integer> login(LoginRequest request);
 }

--- a/src/main/java/com/map/gaja/user/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/map/gaja/user/presentation/dto/request/LoginRequest.java
@@ -1,0 +1,10 @@
+package com.map.gaja.user.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginRequest {
+    private final String accessToken;
+}

--- a/src/main/java/com/map/gaja/user/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/map/gaja/user/presentation/dto/request/LoginRequest.java
@@ -1,10 +1,12 @@
 package com.map.gaja.user.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class LoginRequest {
-    private final String accessToken;
+    @Schema(description = "카카오 액세스 토큰")
+    private String accessToken;
 }

--- a/src/test/java/com/map/gaja/user/infrastructure/Oauth2ClientTest.java
+++ b/src/test/java/com/map/gaja/user/infrastructure/Oauth2ClientTest.java
@@ -1,0 +1,18 @@
+package com.map.gaja.user.infrastructure;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Oauth2ClientTest {
+
+    @Test
+    void oauth2Login() {
+        Oauth2Client oauth2Client = new Oauth2Client();
+        String accessToken = "accessToken";
+
+        String email = oauth2Client.getEmail(accessToken);
+
+        assertEquals(email, "email");
+    }
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #47 

<!--
 전달할 내용
-->
## comment
- 사용자가 로그인에 성공하면 지도페이지로 이동하기 때문에 클라이언트 정보를 리턴하는 걸로 변경해야됨 이 브랜치에다가 이어서 기능 추가할 예정
- 중복로그인에 대한 처리 세션리스너로 따로 브랜치파서 하겠음
- 사용자가 마지막에 선택한 번들이 무엇인지 User 필드에 추가함
- 시큐리티 설정은 배포하기 직전에 따로 브랜치 파서 하겠음
- 번들 변경하면 최근 참조 번들아이디도 변경해야 되고, 번들이 삭제되면 null로 변경해야됨, 또 번들이 생성되면, 참조 번들아이디 변경필요 -> 이 작업도 따로 브랜치파서 하겠음

<!--
 참고한 사이트
-->
## References
- 