### PR TITLE
Feat/#62 /api/bundle/{bundleId}/clinets/{clientId} 경로 변경

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientService.java
@@ -1,10 +1,12 @@
 package com.map.gaja.client.apllication;
 
 import com.map.gaja.client.apllication.exception.UnsupportedFileTypeException;
+import com.map.gaja.client.domain.exception.ClientNotInBundleException;
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.domain.model.ClientAddress;
 import com.map.gaja.client.domain.model.ClientLocation;
 import com.map.gaja.client.infrastructure.file.ClientFileParser;
+import com.map.gaja.client.infrastructure.repository.ClientQueryRepository;
 import com.map.gaja.client.infrastructure.repository.ClientRepository;
 import com.map.gaja.client.presentation.dto.request.NewClientBulkRequest;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
@@ -26,6 +28,7 @@ import static com.map.gaja.client.apllication.ClientConvertor.*;
 @Transactional
 public class ClientService {
     private final ClientRepository clientRepository;
+    private final ClientQueryRepository clientQueryRepository;
     private final List<ClientFileParser> parsers;
 
     public CreatedClientResponse saveClient(NewClientRequest clientRequest) {
@@ -50,10 +53,11 @@ public class ClientService {
         return response;
     }
 
-    public void deleteClient(Long clientId) {
-        Client clientToDelete = clientRepository.findById(clientId)
-                .orElseThrow(() -> new ClientNotFoundException(clientId));
-        clientRepository.delete(clientToDelete);
+    public void deleteClient(Long bundleId, Long clientId) {
+        Client client = clientQueryRepository.findClient(bundleId, clientId)
+                .orElseThrow(() -> new ClientNotInBundleException());
+
+        clientRepository.delete(client);
     }
 
     public CreatedClientListResponse parseFileAndSave(MultipartFile file) {

--- a/src/main/java/com/map/gaja/client/domain/exception/ClientNotInBundleException.java
+++ b/src/main/java/com/map/gaja/client/domain/exception/ClientNotInBundleException.java
@@ -1,0 +1,15 @@
+package com.map.gaja.client.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ClientNotInBundleException extends RuntimeException {
+    private String message = "번들 내에 사용자를 찾을 수 없습니다.";
+    private final HttpStatus status = HttpStatus.NOT_FOUND;
+
+    public ClientNotInBundleException() {
+    }
+
+    public ClientNotInBundleException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -1,5 +1,6 @@
 package com.map.gaja.client.infrastructure.repository;
 
+import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.infrastructure.repository.querydsl.sql.NativeSqlCreator;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientResponse;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.map.gaja.client.domain.model.QClient.client;
 
@@ -52,6 +54,15 @@ public class ClientQueryRepository {
         }
 
         return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    public Optional<Client> findClient(long bundleId, long clientId) {
+        Client result = query
+                .selectFrom(client)
+                .where(client.id.eq(clientId).and(client.bundle.id.eq(bundleId)))
+                .fetchFirst();
+
+        return Optional.ofNullable(result);
     }
 
     private NumberExpression<Double> getLocationDistance(NearbyClientSearchRequest locationSearchCond) {

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/clients")
+@RequestMapping("/api/bundle/{bundleId}/clients")
 @RequiredArgsConstructor
 public class ClientController {
 
@@ -23,10 +23,10 @@ public class ClientController {
     private final S3FileService fileService;
 
     @DeleteMapping("/{clientId}")
-    public ResponseEntity<Void> deleteClient(@PathVariable Long clientId) {
-        // 거래처 삭제
-        log.info("ClientController.deleteClient clinetId={}", clientId);
-        clientService.deleteClient(clientId);
+    public ResponseEntity<Void> deleteClient(@PathVariable Long bundleId, @PathVariable Long clientId) {
+        // 특정 번들 내에 거래처 삭제
+        log.info("ClientController.deleteClient bundleId={} clientId={}", bundleId, clientId);
+        clientService.deleteClient(bundleId, clientId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #62 

<!--
 전달할 내용
-->
## comment
- exist를 한 후에 deleteById를 하면 다시 findById로 조회를 하고 삭제하기 때문에
exist를 안쓰고 findClient 메서드로 Client 객체를 찾아오고 바로 그 객체를 delete로 삭제하도록 만듦

<!--
 참고한 사이트
-->
## References
- 