### PR TITLE
feat: 중복로그인 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+	// session db 설정
+	implementation 'org.springframework.session:spring-session-jdbc'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/map/gaja/global/authentication/AuthenticationToken.java
+++ b/src/main/java/com/map/gaja/global/authentication/AuthenticationToken.java
@@ -24,7 +24,7 @@ public class AuthenticationToken implements Authentication {
 
     @Override
     public Object getDetails() {
-        return null;
+        return email;
     }
 
     @Override
@@ -34,7 +34,7 @@ public class AuthenticationToken implements Authentication {
 
     @Override
     public boolean isAuthenticated() {
-        return false;
+        return true;
     }
 
     @Override
@@ -44,6 +44,6 @@ public class AuthenticationToken implements Authentication {
 
     @Override
     public String getName() {
-        return null;
+        return email;
     }
 }

--- a/src/main/java/com/map/gaja/global/authentication/SessionHandler.java
+++ b/src/main/java/com/map/gaja/global/authentication/SessionHandler.java
@@ -1,0 +1,33 @@
+package com.map.gaja.global.authentication;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class SessionHandler {
+    private final FindByIndexNameSessionRepository findByIndexNameSessionRepository;
+    private final SessionRepository sessionRepository;
+    private static final int LIMIT_SESSION_SIZE = 2;
+    private static final int OLD_SESSION_INDEX = 1;
+
+    @Transactional
+    public void deduplicate(String email) {
+        //해당 이메일에 속한 세션 모두 가져오기
+        Map<String, ? extends Session> sessions = findByIndexNameSessionRepository.findByIndexNameAndIndexValue(JdbcIndexedSessionRepository.PRINCIPAL_NAME_INDEX_NAME, email);
+
+        if (sessions.size() == LIMIT_SESSION_SIZE) {
+            List<? extends Session> sessionList = new ArrayList<>(sessions.values());
+            sessionRepository.deleteById(sessionList.get(OLD_SESSION_INDEX).getId()); //가장 오래된 세션 삭제
+        }
+    }
+}

--- a/src/main/java/com/map/gaja/global/config/SessionJdbcConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SessionJdbcConfig.java
@@ -1,17 +1,8 @@
 package com.map.gaja.global.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
-import org.springframework.transaction.PlatformTransactionManager;
-
-import javax.sql.DataSource;
 
 @EnableJdbcHttpSession(tableName = "session", maxInactiveIntervalInSeconds = 3600)
 public class SessionJdbcConfig {
 
-    @Bean
-    public PlatformTransactionManager transactionManager(DataSource dataSource) {
-        return new DataSourceTransactionManager(dataSource);
-    }
 }

--- a/src/main/java/com/map/gaja/global/config/SessionJdbcConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SessionJdbcConfig.java
@@ -1,0 +1,17 @@
+package com.map.gaja.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@EnableJdbcHttpSession(tableName = "session", maxInactiveIntervalInSeconds = 3600)
+public class SessionJdbcConfig {
+
+    @Bean
+    public PlatformTransactionManager transactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+}

--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -1,6 +1,7 @@
 package com.map.gaja.user.application;
 
 import com.map.gaja.global.authentication.AuthenticationHandler;
+import com.map.gaja.global.authentication.SessionHandler;
 import com.map.gaja.user.domain.exception.UserNotFoundException;
 import com.map.gaja.user.domain.model.Authority;
 import com.map.gaja.user.domain.model.User;
@@ -20,6 +21,7 @@ public class UserService {
     private final Oauth2Client oauth2Client;
     private final UserRepository userRepository;
     private final AuthenticationHandler authenticationHandler;
+    private final SessionHandler sessionHandler;
 
     @Transactional
     public Integer login(LoginRequest request) {
@@ -27,6 +29,8 @@ public class UserService {
         if (email == null) { //카카오 로그인 실패
             throw new UserNotFoundException();
         }
+
+        sessionHandler.deduplicate(email); //중복로그인 처리 최대 2개까지
 
         User user = userRepository.findByEmail(email)
                 .orElse(User.builder()


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #49 

<!--
 전달할 내용
-->
## comment
- spring-session-jdbc 사용하기 위한 yml정보
```
spring:
  session:
    store-type: jdbc
    jdbc:
      initialize-schema: never
```
- 세션 관련된 db테이블을 2개 생성해야 되는데 시도는 해봤지만 커스터마이징이 잘 안돼서 쓰지도 않는 session_attribute라는 테이블도 생성해야함 생성 안 하면 세션만들 때 오류뜸.
- 테이블도 직접 mysql에서 생성해 줘야함 관련된 sql은 카톡으로 드림
- 웹, 앱 상관없이 2개까지 로그인 가능함.
- 클라이언트의 요청할 때마다 세션을 인메모리가 아닌 db로 변경했기 때문에 세션 db조회가 1번씩은 일어남 나중에 redis로 변경 가능
- 세션이 너무 까다롭고 불필요한 테이블도 생성되고 커스터마이징도 힘들고 jwt로 변경하는게 좋아보이면 jwt로 다시 하겠음 jwt가 훨배 쉬울듯;;
- 웹이랑 앱로그인 구별할 수 있도록 커스터마이징하는 법 계속 알아보겠음

<!--
 참고한 사이트
-->
## References
- 