### PR TITLE
Fix/#81 Client 삭제 API 권한 검사까지 하도록 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/domain/model/Client.java
+++ b/src/main/java/com/map/gaja/client/domain/model/Client.java
@@ -73,13 +73,18 @@ public class Client extends BaseTimeEntity {
         updateClientImage(clientImage);
     }
 
+    public void removeBundle() {
+        bundle.decreaseClientCount();
+        bundle = null;
+    }
+
     private void setBundle(Bundle bundle) {
         this.bundle = bundle;
         bundle.increaseClientCount();
     }
 
     private void updateBundle(Bundle bundle) {
-        this.bundle.decreaseClientCount();
+        removeBundle();
         setBundle(bundle);
     }
 

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -57,11 +57,12 @@ public class ClientQueryRepository {
         return new SliceImpl<>(result, pageable, hasNext);
     }
 
-    public Optional<Client> findClient(long bundleId, long clientId) {
+    public Optional<Client> findClientWithBundle(long clientId) {
         Client result = query
                 .selectFrom(client)
-                .where(client.id.eq(clientId).and(client.bundle.id.eq(bundleId)))
-                .fetchFirst();
+                .join(client.bundle, bundle)
+                .where(client.id.eq(clientId))
+                .fetchJoin().fetchOne();
 
         return Optional.ofNullable(result);
     }

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -2,6 +2,7 @@ package com.map.gaja.client.presentation.api;
 
 import com.map.gaja.client.apllication.ClientService;
 import com.map.gaja.client.infrastructure.s3.S3FileService;
+import com.map.gaja.client.presentation.dto.ClientAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.NewClientBulkRequest;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
 import com.map.gaja.client.presentation.dto.response.*;
@@ -24,10 +25,11 @@ public class ClientController {
     private final S3FileService fileService;
 
     @DeleteMapping("/bundle/{bundleId}/clients/{clientId}")
-    public ResponseEntity<Void> deleteClient(@PathVariable Long bundleId, @PathVariable Long clientId) {
+    public ResponseEntity<Void> deleteClient(@LoginEmail String loginEmail, @PathVariable Long bundleId, @PathVariable Long clientId) {
         // 특정 번들 내에 거래처 삭제
-        log.info("ClientController.deleteClient bundleId={} clientId={}", bundleId, clientId);
-        clientService.deleteClient(bundleId, clientId);
+        log.info("ClientController.deleteClient loginEmail={} bundleId={} clientId={}", loginEmail, bundleId, clientId);
+        ClientAccessCheckDto accessCheckDto = new ClientAccessCheckDto(loginEmail, bundleId, clientId);
+        clientService.deleteClient(accessCheckDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #81 

<!--
 전달할 내용
-->
## comment
- Client 삭제할 때 권한 검사까지 하도록 수정
- Client내에 removeBundle 메소드 추가

<!--
 참고한 사이트
-->
## References
- 