### PR TITLE
Fix/#122 client 업데이트 로직 수정 fix

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -59,8 +59,8 @@ public class ClientConvertor {
         return new Client(
                 request.getClientName(),
                 request.getPhoneNumber(),
-                new ClientAddress(address.getProvince(), address.getCity(), address.getDistrict(), address.getDetail()),
-                new ClientLocation(location.getLatitude(), location.getLongitude()),
+                dtoToVo(address),
+                dtoToVo(location),
                 group
             );
     }
@@ -72,10 +72,20 @@ public class ClientConvertor {
         return new Client(
                 request.getClientName(),
                 request.getPhoneNumber(),
-                new ClientAddress(address.getProvince(), address.getCity(), address.getDistrict(), address.getDetail()),
-                new ClientLocation(location.getLatitude(), location.getLongitude()),
+                dtoToVo(address),
+                dtoToVo(location),
                 group,
                 clientImage
         );
     }
+
+    protected static ClientLocation dtoToVo(LocationDto location) {
+        return new ClientLocation(location.getLatitude(), location.getLongitude());
+    }
+
+    protected static ClientAddress dtoToVo(AddressDto address) {
+        return new ClientAddress(address.getProvince(), address.getCity(), address.getDistrict(), address.getDetail());
+    }
+
+
 }

--- a/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
@@ -1,5 +1,6 @@
 package com.map.gaja.client.apllication;
 
+import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.map.gaja.group.domain.exception.GroupNotFoundException;
 import com.map.gaja.group.infrastructure.GroupQueryRepository;
 import com.map.gaja.client.domain.model.Client;
@@ -55,4 +56,8 @@ public class ClientQueryService {
         return new ClientListResponse(clientList);
     }
 
+    public StoredFileDto findClientImage(Long clientId) {
+        ClientResponse client = findClient(clientId);
+        return client.getImage();
+    }
 }

--- a/src/main/java/com/map/gaja/client/apllication/ClientService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientService.java
@@ -1,5 +1,6 @@
 package com.map.gaja.client.apllication;
 
+import com.map.gaja.client.domain.model.ClientImage;
 import com.map.gaja.group.domain.exception.GroupNotFoundException;
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.group.infrastructure.GroupRepository;
@@ -88,7 +89,8 @@ public class ClientService {
 
     public ClientResponse changeClient(
             Long existingClientId,
-            NewClientRequest updateRequest
+            NewClientRequest updateRequest,
+            StoredFileDto updatedFileDto
     ) {
         Client existingClient = clientQueryRepository.findClientWithGroup(existingClientId)
                 .orElseThrow(() -> new ClientNotFoundException());
@@ -97,26 +99,26 @@ public class ClientService {
         Group updatedGroup = groupRepository.findById(updateRequest.getGroupId())
                 .orElseThrow(GroupNotFoundException::new);
 
-        ClientAddress updatedAddress = new ClientAddress(
-                updateRequest.getAddress().getProvince(),
-                updateRequest.getAddress().getCity(),
-                updateRequest.getAddress().getDistrict(),
-                updateRequest.getAddress().getDetail()
-        );
-
-        ClientLocation updatedLocation = new ClientLocation(
-                updateRequest.getLocation().getLatitude(),
-                updateRequest.getLocation().getLongitude()
-        );
+        ClientAddress updatedAddress = dtoToVo(updateRequest.getAddress());
+        ClientLocation updatedLocation = dtoToVo(updateRequest.getLocation());
+        ClientImage updatedClientImage = existingClient.getClientImage();
+        if (isNewFileDto(updatedFileDto)) {
+            updatedClientImage = new ClientImage(updatedFileDto.getOriginalFileName(), updatedFileDto.getFilePath());
+        }
 
         existingClient.updateClient(
                 updateRequest.getClientName(),
                 updateRequest.getPhoneNumber(),
                 updatedAddress,
                 updatedLocation,
-                updatedGroup
+                updatedGroup,
+                updatedClientImage
         );
 
         return entityToDto(existingClient);
+    }
+
+    private boolean isNewFileDto(StoredFileDto updatedFileDto) {
+        return updatedFileDto.getOriginalFileName() != null && updatedFileDto.getOriginalFileName() != null;
     }
 }

--- a/src/main/java/com/map/gaja/client/domain/model/Client.java
+++ b/src/main/java/com/map/gaja/client/domain/model/Client.java
@@ -54,13 +54,6 @@ public class Client extends BaseTimeEntity {
         this.clientImage = clientImage;
     }
 
-    public void updateClient(String name, String phoneNumber, ClientAddress address, ClientLocation location, Group group) {
-        updateName(name);
-        updatePhoneNumber(phoneNumber);
-        updateLocation(location, address);
-        updateGroup(group);
-    }
-
     public void updateClient(String name, String phoneNumber, ClientAddress address, ClientLocation location, Group group, ClientImage clientImage) {
         updateName(name);
         updatePhoneNumber(phoneNumber);

--- a/src/main/java/com/map/gaja/client/presentation/dto/subdto/StoredFileDto.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/subdto/StoredFileDto.java
@@ -2,8 +2,10 @@ package com.map.gaja.client.presentation.dto.subdto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class StoredFileDto {
     private String filePath;

--- a/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
@@ -1,6 +1,7 @@
 package com.map.gaja.client.apllication;
 
 import com.map.gaja.client.domain.model.ClientImage;
+import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.group.infrastructure.GroupRepository;
 import com.map.gaja.client.domain.model.Client;
@@ -100,7 +101,7 @@ class ClientServiceTest {
                 .thenReturn(Optional.ofNullable(changedGroup));
 
         // when
-        ClientResponse response = clientService.changeClient(existingClientId, changedRequest);
+        ClientResponse response = clientService.changeClient(existingClientId, changedRequest, new StoredFileDto());
 
         // then
         assertThat(response.getClientName()).isEqualTo(changedName);


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #122 

<!--
 전달할 내용
-->
## comment
- `example3@test.com/uuid-aa.png` 라는 주소를 저장된 URL로 반환할 때
`@`를 `%40`으로 인코딩해서 `example3%40test.com/uuid-aa.png`로 준다. 
그래서 DB에서 savedPath를 가져와서 s3 delete를 시도하면 해당 객체를 찾지 못하는 현상이 발생한다.
회의 후에 나중 이슈에서 fix한다
- 현재 로직은 Original-파일명을 가지고 같은 이미지 파일인지 파악한다.
즉 같은 파일명을 가지고 있는 이미지 파일로 클라이언트 이미지를 변경하면 이미지 변경이 안된다.

<!--
 참고한 사이트
-->
## References
- 