### PR TITLE
Fix/#124 반경 검색 API와 사용자 검색 API 분리

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
@@ -11,6 +11,8 @@ import com.map.gaja.client.presentation.dto.response.ClientListResponse;
 import com.map.gaja.client.presentation.dto.response.ClientResponse;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,5 +61,13 @@ public class ClientQueryService {
     public StoredFileDto findClientImage(Long clientId) {
         ClientResponse client = findClient(clientId);
         return client.getImage();
+    }
+
+    public ClientListResponse findAllClient(
+            String loginEmail,
+            @Nullable String nameCond
+    ) {
+        List<ClientResponse> clientList = clientQueryRepository.findAllClientByEmail(loginEmail, nameCond);
+        return new ClientListResponse(clientList);
     }
 }

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -236,6 +236,7 @@ public class ClientQueryRepository {
                 .join(client.group, group)
                 .join(client.group.user, user)
                 .where(user.email.eq(loginEmail), nameContains(nameCond))
+                .orderBy(client.createdAt.desc())
                 .fetch();
 
         return result;

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -1,7 +1,6 @@
 package com.map.gaja.client.infrastructure.repository;
 
 import com.map.gaja.client.domain.model.Client;
-import com.map.gaja.client.domain.model.QClientImage;
 import com.map.gaja.client.infrastructure.repository.querydsl.sql.NativeSqlCreator;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientResponse;
@@ -11,7 +10,6 @@ import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +35,7 @@ public class ClientQueryRepository {
      * 반경 검색 동적 쿼리
      * groupIdList.size < 1 이면 그룹에 포함된 Client가 아니기 때문에 비어있는 ArrayList 반환
      * groupIdList.size >= 1 이면 groupIdList에 포함된 Client를 검색
-     * NearbyClientSearchRequest에 위도, 경도 정보가 없다면 생성일로 정렬
-     * 위도, 경도 정보가 있다면 위도 경도를 기준으로 거리를 계산하여 거리순으로 정렬
+     * 위도 경도를 기준으로 거리를 계산하여 거리순으로 정렬
      * NearbyClientSearchRequest에 radius로 검색 반경 설정
      * wordCond가 있다면 Client Name으로 맞는 Client가 있는지 확인
      *
@@ -47,7 +44,7 @@ public class ClientQueryRepository {
      * @param wordCond
      * @return
      */
-    public List<ClientResponse> findClientByConditions(List<Long> groupIdList, NearbyClientSearchRequest locationSearchCond, String wordCond) {
+    public List<ClientResponse> findClientByConditions(List<Long> groupIdList, NearbyClientSearchRequest locationSearchCond, @Nullable String wordCond) {
         if (groupIdList.size() < 1) {
             return new ArrayList<>();
         }
@@ -55,14 +52,13 @@ public class ClientQueryRepository {
         List<ClientResponse> result = query.select(
                         Projections.constructor(ClientResponse.class,
                                 client.id,
-//                                client.group.id,
                                 Projections.constructor(GroupInfoDto.class, client.group.id, client.group.name),
                                 client.name,
                                 client.phoneNumber,
                                 client.address,
                                 client.location,
                                 Projections.constructor(StoredFileDto.class, client.clientImage.savedPath, client.clientImage.originalName),
-                                getLocationDistance(locationSearchCond) // 좌표 정보가 없다면 -1을 반환함
+                                getCalcDistanceWithNativeSQL(locationSearchCond.getLocation())
                         )
                 )
                 .from(client)
@@ -108,49 +104,21 @@ public class ClientQueryRepository {
         return result;
     }
 
-    private NumberExpression<Double> getLocationDistance(NearbyClientSearchRequest locationSearchCond) {
-        if(isLocationSearchCondEmpty(locationSearchCond)) {
-            return Expressions.asNumber(-1.0);
-        }
-
-        return getCalcDistanceNativeSQL(locationSearchCond.getLocation());
-    }
-
     private OrderSpecifier<?> distanceAsc(NearbyClientSearchRequest locationCond) {
-        if(locationCond == null || isCurrentLocationEmpty(locationCond.getLocation())) {
-            return new OrderSpecifier(Order.ASC, NullExpression.DEFAULT, OrderSpecifier.NullHandling.Default);
-        }
-
-        return getCalcDistanceNativeSQL(locationCond.getLocation()).asc();
+        return getCalcDistanceWithNativeSQL(locationCond.getLocation()).asc();
     }
 
     private BooleanExpression isClientInRadius(NearbyClientSearchRequest locationSearchCond) {
-        if(isLocationSearchCondEmpty(locationSearchCond)) {
-            return null;
-        }
-
         LocationDto currentLocation = locationSearchCond.getLocation();
-        return getCalcDistanceNativeSQL(currentLocation)
+        return getCalcDistanceWithNativeSQL(currentLocation)
                 .loe(locationSearchCond.getRadius());
     }
 
-    private NumberExpression<Double> getCalcDistanceNativeSQL(LocationDto currentLocation) {
+    private NumberExpression<Double> getCalcDistanceWithNativeSQL(LocationDto currentLocation) {
         return mysqlNativeSQLCreator.createCalcDistanceSQL(
                 currentLocation.getLongitude(), currentLocation.getLatitude(),
                 client.location.longitude, client.location.latitude
         );
-    }
-
-    private boolean isLocationSearchCondEmpty(NearbyClientSearchRequest locationSearchCond) {
-        return locationSearchCond == null
-                || isCurrentLocationEmpty(locationSearchCond.getLocation())
-                || locationSearchCond.getRadius() == null;
-    }
-
-    private boolean isCurrentLocationEmpty(LocationDto currentLocation) {
-        return currentLocation == null
-                || currentLocation.getLatitude() == null
-                || currentLocation.getLongitude() == null;
     }
 
     private BooleanExpression nameContains(String nameCond) {
@@ -163,25 +131,6 @@ public class ClientQueryRepository {
         }
 
         return client.group.id.in(groupIdList);
-    }
-
-    private BooleanBuilder allContains(String wordCond) {
-        BooleanBuilder builder = new BooleanBuilder();
-
-        return builder.or(nameContains(wordCond))
-                .or(addressContains(wordCond))
-                .or(phoneNumberContains(wordCond));
-    }
-
-    private BooleanExpression phoneNumberContains(String phoneNumberCond) {
-        return phoneNumberCond != null ? client.phoneNumber.contains(phoneNumberCond) : null;
-    }
-
-    private BooleanExpression addressContains(String addressCond) {
-        return addressCond != null ? client.address.city.contains(addressCond)
-                .or(client.address.province.contains(addressCond))
-                .or(client.address.district.contains(addressCond))
-                .or(client.address.detail.contains(addressCond)) : null;
     }
 
     /**

--- a/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
@@ -77,6 +77,16 @@ public class GetClientController implements ClientQueryApiSpecification {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    @GetMapping("/api/clients")
+    public ResponseEntity<ClientListResponse> getAllClients(
+            @AuthenticationPrincipal String loginEmail,
+            @RequestParam(required = false) String wordCond
+    ) {
+        // 사용자가 가지고 있는 전체 고객 조회
+        ClientListResponse response = clientQueryService.findAllClient(loginEmail, wordCond);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
     private void verifyClientAccess(String loginEmail, Long groupId, Long clientId) {
         ClientAccessCheckDto accessCheckDto = new ClientAccessCheckDto(loginEmail, groupId, clientId);
         clientAccessVerifyService.verifyClientAccess(accessCheckDto);

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/ClientQueryApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/ClientQueryApiSpecification.java
@@ -19,13 +19,13 @@ import org.springframework.web.bind.annotation.*;
 
 public interface ClientQueryApiSpecification {
 
-    @Operation(summary = "특정 그룹내에 특정 거래처 조회",
+    @Operation(summary = "특정 그룹내에 특정 고객 조회",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 client가 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
     @GetMapping("/api/group/{groupId}/clients/{clientId}")
     public ResponseEntity<ClientResponse> getClient(
@@ -34,13 +34,13 @@ public interface ClientQueryApiSpecification {
             @PathVariable Long clientId
     );
 
-    @Operation(summary = "특정 그룹내에 거래처 전부 조회",
+    @Operation(summary = "특정 그룹내에 고객 전부 조회",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 client가 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
     @GetMapping("/api/group/{groupId}/clients")
     public ResponseEntity<ClientListResponse> getClientList(
@@ -48,16 +48,16 @@ public interface ClientQueryApiSpecification {
             @PathVariable Long groupId
     );
 
-    @Operation(summary = "반경 검색",
-            description = "현재 사용자 위치에서 특정 그룹내에 고객들을 대상으로 반경 검색",
+    @Operation(summary = "특정 그룹내에 고객 반경 검색",
+            description = "현재 사용자 위치에서 특정 그룹내에 고객들을 대상으로 반경 검색 - 가장 가까운 순으로 정렬",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
-                    @Parameter(name = "wordCond", description = "조회할 거래처 이름"),
+                    @Parameter(name = "wordCond", description = "조회할 고객 이름"),
                     @Parameter(name = "locationSearchCond", description = "반경 검색 조건", content = @Content(schema = @Schema(implementation = NearbyClientSearchRequest.class)))
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 client가 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
     @GetMapping("/api/group/{groupId}/clients/nearby")
     public ResponseEntity<ClientListResponse> nearbyClientSearch(
@@ -67,21 +67,37 @@ public interface ClientQueryApiSpecification {
             @RequestParam(required = false) String wordCond
     );
 
-    @Operation(summary = "전체 고객들 반경 검색",
-            description = "현재 사용자 위치에서 전체 고객들을 대상으로 반경 검색",
+    @Operation(summary = "전체 고객 대상 반경 검색",
+            description = "현재 사용자 위치에서 전체 고객들을 대상으로 반경 검색 - 가장 가까운 순으로 정렬",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
-                    @Parameter(name = "wordCond", description = "조회할 거래처 이름"),
+                    @Parameter(name = "wordCond", description = "조회할 고객 이름"),
                     @Parameter(name = "locationSearchCond", description = "반경 검색 조건", content = @Content(schema = @Schema(implementation = NearbyClientSearchRequest.class)))
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 client가 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
     @GetMapping("/api/clients/nearby")
     public ResponseEntity<ClientListResponse> nearbyClientSearch(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @ModelAttribute NearbyClientSearchRequest locationSearchCond,
+            @RequestParam(required = false) String wordCond
+    );
+
+    @Operation(summary = "전체 고객 검색",
+            description = "사용자가 가지고 있는 전체 고객 검색 - 생성일을 기준으로 최신순 정렬",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+                    @Parameter(name = "wordCond", description = "조회할 고객 이름"),
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+            })
+    @GetMapping("/api/clients")
+    public ResponseEntity<ClientListResponse> getAllClients(
+            @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @RequestParam(required = false) String wordCond
     );
 }

--- a/src/main/java/com/map/gaja/client/presentation/dto/response/ClientResponse.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/response/ClientResponse.java
@@ -31,4 +31,14 @@ public class ClientResponse {
     private StoredFileDto image;
     @Schema(description = "현재 위치에서 떨어진 거리(M - 미터)", example = "2398")
     private Double distance; // km 기준
+
+    public ClientResponse(Long clientId, GroupInfoDto groupInfo, String clientName, String phoneNumber, ClientAddress address, ClientLocation location, StoredFileDto image) {
+        this.clientId = clientId;
+        this.groupInfo = groupInfo;
+        this.clientName = clientName;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.location = location;
+        this.image = image;
+    }
 }

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
@@ -196,4 +196,16 @@ class ClientQueryRepositoryTest {
         }));
     }
 
+    @Test
+    @DisplayName("로그인 한 유저가 가지고 있는 Client 검색")
+    void ss() {
+        String nameCond = "사용자";
+
+        List<ClientResponse> result = clientQueryRepository.findAllClientByEmail(user.getEmail(), nameCond);
+
+        assertThat(result.size()).isEqualTo(group1ClientList.size() + group2ClientList.size());
+        result.forEach((client) -> {
+            assertThat(client.getClientName()).contains(nameCond);
+        });
+    }
 }

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
@@ -101,26 +101,6 @@ class ClientQueryRepositoryTest {
         return createdUser;
     }
 
-
-    @Test
-    @DisplayName("위치 정보 없이 반경 검색")
-    void findClientWithoutGPSTest() {
-        String nameKeyword = "사용자";
-        Long groupId = group2.getId();
-        String groupName = group2.getName();
-        List<Long> groupIdList = new ArrayList<>();
-        groupIdList.add(groupId);
-        List<ClientResponse> result = clientQueryRepository.findClientByConditions(groupIdList, null,nameKeyword);
-
-        assertThat(result.size()).isEqualTo(group2ClientList.size());
-        result.forEach((client) -> {
-            assertThat(client.getClientName()).contains(nameKeyword);
-            assertThat(client.getDistance()).isEqualTo(-1);
-            assertThat(client.getGroupInfo().getGroupId()).isEqualTo(groupId);
-            assertThat(client.getGroupInfo().getGroupName()).isEqualTo(groupName);
-        });
-    }
-
     @Test
     @DisplayName("위치 정보 포함 반경 검색")
     void findClientWithGPSTest() {


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #124 

<!--
 전달할 내용
-->
## comment
- `GET:/api/clients` 로그인한 사용자의 고객 전체 검색 로직 추가
- 반경 검색시에 반경 검색 조건을 필수로 사용해서 쿼리하도록 변경


<!--
 참고한 사이트
-->
## References
- 