### PR TITLE
feat: validation 에러 공통 처리 추가

### DIFF
--- a/src/main/java/com/map/gaja/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/map/gaja/global/exception/GlobalExceptionHandler.java
@@ -4,8 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.ArrayList;
@@ -35,9 +39,11 @@ public class GlobalExceptionHandler {
 
     /**
      * Valid 어노테이션에서 걸리는 경우
+     * Form 형식 -> BindException
+     * Json 형식 -> MethodArgumentNotValidException
      */
-    @ExceptionHandler
-    public ResponseEntity<CommonErrorResponse> validationErrorHandle(MethodArgumentNotValidException e) {
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<CommonErrorResponse> validationErrorHandle(BindException e) {
         List<ValidationErrorInfo> body = new ArrayList<>();
         e.getAllErrors().stream().forEach(
                 error -> body.add(
@@ -45,9 +51,9 @@ public class GlobalExceptionHandler {
                 )
         );
 
-        log.info("Validation 걸림");
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
+
 
     /**
      * RequestBody로 들어온 값을 객체 파싱할 수 없는 경우


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #156 

<!--
 전달할 내용
-->
## comment
- validation 에러 공통 처리 추가
- 추후 웹 추가시에도 RestControllerAdvice로 공통처리 되기 때문에 분리가 필요함.
굳이 message를 추가할 필요없음 디폴트 message를 제공함
- 반환 타입이 ExceptionDto가 아니기 때문에 모바일에서 List<ValidationErrorInfo>을 받을 수 있도록 만들어줘야함
![image](https://github.com/GaJaMap/backend/assets/88225377/c6c8bedf-9afe-433d-9351-4cbe36dfca55)


<!--
 참고한 사이트
-->
## References
- 