### PR TITLE
Group, Client 접근 권한 검사시에 isDeleted 정보도 포함하도록 변경

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
@@ -47,16 +47,6 @@ public class ClientQueryService {
         return new ClientListResponse(clientList);
     }
 
-    public ClientListResponse findClientByConditions(String loginEmail, NearbyClientSearchRequest locationSearchCond, String wordCond) {
-        List<Long> groupIdList = groupQueryRepository.findGroupId(loginEmail);
-        if (groupIdList.size() == 0) {
-            throw new GroupNotFoundException();
-        }
-
-        List<ClientResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
-        return new ClientListResponse(clientList);
-    }
-
     public StoredFileDto findClientImage(Long clientId) {
         ClientResponse client = findClient(clientId);
         return client.getImage();
@@ -66,7 +56,17 @@ public class ClientQueryService {
             String loginEmail,
             @Nullable String nameCond
     ) {
-        List<ClientResponse> clientList = clientQueryRepository.findAllClientByEmail(loginEmail, nameCond);
+        List<ClientResponse> clientList = clientQueryRepository.findActiveClientByEmail(loginEmail, nameCond);
+        return new ClientListResponse(clientList);
+    }
+
+    public ClientListResponse findClientByConditions(String loginEmail, NearbyClientSearchRequest locationSearchCond, String wordCond) {
+        List<Long> groupIdList = groupQueryRepository.findActiveGroup(loginEmail);
+        if (groupIdList.size() == 0) {
+            throw new GroupNotFoundException();
+        }
+
+        List<ClientResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
         return new ClientListResponse(clientList);
     }
 }

--- a/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
@@ -1,13 +1,9 @@
 package com.map.gaja.client.presentation.api;
 
-import com.map.gaja.client.presentation.api.specification.ClientQueryApiSpecification;
-import com.map.gaja.group.application.GroupAccessVerifyService;
-import com.map.gaja.client.apllication.ClientAccessVerifyService;
 import com.map.gaja.client.apllication.ClientQueryService;
-import com.map.gaja.client.presentation.dto.ClientAccessCheckDto;
+import com.map.gaja.client.presentation.api.specification.ClientQueryApiSpecification;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -17,58 +13,15 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-/**
- * ReadOnly Client 컨트롤러
- */
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/clients")
 public class GetClientController implements ClientQueryApiSpecification {
+
     private final ClientQueryService clientQueryService;
-    private final ClientAccessVerifyService clientAccessVerifyService;
-    private final GroupAccessVerifyService groupAccessVerifyService;
 
-    @GetMapping("/api/group/{groupId}/clients/{clientId}")
-    public ResponseEntity<ClientResponse> getClient(
-            @AuthenticationPrincipal String loginEmail,
-            @PathVariable Long groupId,
-            @PathVariable Long clientId
-    ) {
-        // 거래처 조회
-        log.info("ClientController.getClient clientId={}", clientId);
-        verifyClientAccess(loginEmail,groupId,clientId);
-        ClientResponse response = clientQueryService.findClient(clientId);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping("/api/group/{groupId}/clients")
-    public ResponseEntity<ClientListResponse> getClientList(
-            @AuthenticationPrincipal String loginEmail,
-            @PathVariable Long groupId,
-            @RequestParam(required = false) String wordCond
-    ) {
-        // 특정 번들 내에 모든 거래처 조회
-        log.info("GetClientController.getClientList groupId={}", groupId);
-        verifyGroupAccess(loginEmail, groupId);
-        ClientListResponse response = clientQueryService.findAllClientsInGroup(groupId, wordCond);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping("/api/group/{groupId}/clients/nearby")
-    public ResponseEntity<ClientListResponse> nearbyClientSearch(
-            @AuthenticationPrincipal String loginEmail,
-            @PathVariable Long groupId,
-            @Valid @ModelAttribute NearbyClientSearchRequest locationSearchCond,
-            @RequestParam(required = false) String wordCond
-    ) {
-        // 주변 거래처 조회
-        log.info("GetClientController.nearbyClientSearch params={},{},{}", groupId, locationSearchCond, wordCond);
-        verifyGroupAccess(loginEmail, groupId);
-        ClientListResponse response = clientQueryService.findClientByConditions(groupId, locationSearchCond, wordCond);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping("/api/clients/nearby")
+    @GetMapping("/nearby")
     public ResponseEntity<ClientListResponse> nearbyClientSearch(
             @AuthenticationPrincipal String loginEmail,
             @Valid @ModelAttribute NearbyClientSearchRequest locationSearchCond,
@@ -80,7 +33,7 @@ public class GetClientController implements ClientQueryApiSpecification {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping("/api/clients")
+    @GetMapping
     public ResponseEntity<ClientListResponse> getAllClients(
             @AuthenticationPrincipal String loginEmail,
             @RequestParam(required = false) String wordCond
@@ -88,14 +41,5 @@ public class GetClientController implements ClientQueryApiSpecification {
         // 사용자가 가지고 있는 전체 고객 조회
         ClientListResponse response = clientQueryService.findAllClient(loginEmail, wordCond);
         return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    private void verifyClientAccess(String loginEmail, Long groupId, Long clientId) {
-        ClientAccessCheckDto accessCheckDto = new ClientAccessCheckDto(loginEmail, groupId, clientId);
-        clientAccessVerifyService.verifyClientAccess(accessCheckDto);
-    }
-
-    private void verifyGroupAccess(String loginEmail, long groupId) {
-        groupAccessVerifyService.verifyGroupAccess(groupId, loginEmail);
     }
 }

--- a/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
@@ -1,0 +1,79 @@
+package com.map.gaja.client.presentation.api;
+
+import com.map.gaja.client.presentation.api.specification.GroupClientQueryApiSpecification;
+import com.map.gaja.group.application.GroupAccessVerifyService;
+import com.map.gaja.client.apllication.ClientAccessVerifyService;
+import com.map.gaja.client.apllication.ClientQueryService;
+import com.map.gaja.client.presentation.dto.ClientAccessCheckDto;
+import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
+import com.map.gaja.client.presentation.dto.response.ClientListResponse;
+import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+/**
+ * ReadOnly Client 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class GetGroupClientController implements GroupClientQueryApiSpecification {
+    private final ClientQueryService clientQueryService;
+    private final ClientAccessVerifyService clientAccessVerifyService;
+    private final GroupAccessVerifyService groupAccessVerifyService;
+
+    @GetMapping("/api/group/{groupId}/clients/{clientId}")
+    public ResponseEntity<ClientResponse> getClient(
+            @AuthenticationPrincipal String loginEmail,
+            @PathVariable Long groupId,
+            @PathVariable Long clientId
+    ) {
+        // 거래처 조회
+        log.info("ClientController.getClient clientId={}", clientId);
+        verifyClientAccess(loginEmail,groupId,clientId);
+        ClientResponse response = clientQueryService.findClient(clientId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/api/group/{groupId}/clients")
+    public ResponseEntity<ClientListResponse> getClientList(
+            @AuthenticationPrincipal String loginEmail,
+            @PathVariable Long groupId,
+            @RequestParam(required = false) String wordCond
+    ) {
+        // 특정 번들 내에 모든 거래처 조회
+        log.info("GetClientController.getClientList groupId={}", groupId);
+        verifyGroupAccess(loginEmail, groupId);
+        ClientListResponse response = clientQueryService.findAllClientsInGroup(groupId, wordCond);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/api/group/{groupId}/clients/nearby")
+    public ResponseEntity<ClientListResponse> nearbyClientSearch(
+            @AuthenticationPrincipal String loginEmail,
+            @PathVariable Long groupId,
+            @Valid @ModelAttribute NearbyClientSearchRequest locationSearchCond,
+            @RequestParam(required = false) String wordCond
+    ) {
+        // 주변 거래처 조회
+        log.info("GetClientController.nearbyClientSearch params={},{},{}", groupId, locationSearchCond, wordCond);
+        verifyGroupAccess(loginEmail, groupId);
+        ClientListResponse response = clientQueryService.findClientByConditions(groupId, locationSearchCond, wordCond);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private void verifyClientAccess(String loginEmail, Long groupId, Long clientId) {
+        ClientAccessCheckDto accessCheckDto = new ClientAccessCheckDto(loginEmail, groupId, clientId);
+        clientAccessVerifyService.verifyClientAccess(accessCheckDto);
+    }
+
+    private void verifyGroupAccess(String loginEmail, long groupId) {
+        groupAccessVerifyService.verifyGroupAccess(groupId, loginEmail);
+    }
+}

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/GroupClientQueryApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/GroupClientQueryApiSpecification.java
@@ -2,6 +2,7 @@ package com.map.gaja.client.presentation.api.specification;
 
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
+import com.map.gaja.client.presentation.dto.response.ClientResponse;
 import com.map.gaja.global.exception.ExceptionDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,15 +12,47 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-public interface ClientQueryApiSpecification {
-    @Operation(summary = "전체 고객 대상 반경 검색",
-            description = "현재 사용자 위치에서 전체 고객들을 대상으로 반경 검색 - 가장 가까운 순으로 정렬",
+public interface GroupClientQueryApiSpecification {
+
+    @Operation(summary = "특정 그룹내에 특정 고객 조회",
+            description = "위치 정보가 없기 때문에 distance 필드는 null로 초기화됩니다.",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+            })
+    @GetMapping("/api/group/{groupId}/clients/{clientId}")
+    public ResponseEntity<ClientResponse> getClient(
+            @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
+            @PathVariable Long groupId,
+            @PathVariable Long clientId
+    );
+
+    @Operation(summary = "특정 그룹내에 고객 전부 조회",
+            description = "위치 정보가 없기 때문에 distance 필드는 null로 초기화됩니다.",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+                    @Parameter(name = "wordCond", description = "조회할 고객 이름")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+            })
+    @GetMapping("/api/group/{groupId}/clients")
+    public ResponseEntity<ClientListResponse> getClientList(
+            @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
+            @PathVariable Long groupId,
+            @RequestParam(required = false) String wordCond
+    );
+
+    @Operation(summary = "특정 그룹내에 고객 반경 검색",
+            description = "현재 사용자 위치에서 특정 그룹내에 고객들을 대상으로 반경 검색 - 가장 가까운 순으로 정렬",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
                     @Parameter(name = "wordCond", description = "조회할 고객 이름"),
@@ -29,27 +62,11 @@ public interface ClientQueryApiSpecification {
                     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
                     @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
-    @GetMapping("/api/clients/nearby")
+    @GetMapping("/api/group/{groupId}/clients/nearby")
     public ResponseEntity<ClientListResponse> nearbyClientSearch(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
+            @PathVariable Long groupId,
             @Valid @ModelAttribute NearbyClientSearchRequest locationSearchCond,
-            @RequestParam(required = false) String wordCond
-    );
-
-    @Operation(summary = "전체 고객 검색",
-            description = "사용자가 가지고 있는 전체 고객 검색 - 생성일을 기준으로 최신순 정렬" +
-                    "<br>위치 정보가 없기 때문에 distance 필드는 null로 초기화됩니다.",
-            parameters = {
-                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
-                    @Parameter(name = "wordCond", description = "조회할 고객 이름"),
-            },
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientListResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
-            })
-    @GetMapping("/api/clients")
-    public ResponseEntity<ClientListResponse> getAllClients(
-            @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @RequestParam(required = false) String wordCond
     );
 }

--- a/src/main/java/com/map/gaja/group/application/GroupAccessVerifyService.java
+++ b/src/main/java/com/map/gaja/group/application/GroupAccessVerifyService.java
@@ -14,9 +14,21 @@ public class GroupAccessVerifyService {
     private final GroupQueryRepository groupQueryRepository;
 
     public void verifyGroupAccess(long groupId, String userEmail) {
-        Group group = groupQueryRepository.findGroupByUser(groupId, userEmail)
+        Group group = groupQueryRepository.findGroupWithUser(groupId)
                 .orElseThrow(GroupNotFoundException::new);
 
+        if (isNotMatchingEmail(group, userEmail) || isDeleted(group)) {
+            throw new GroupNotFoundException();
+        }
+
         group.getUser().accessGroup(groupId);
+    }
+
+    private static boolean isNotMatchingEmail(Group group, String userEmail) {
+        return !group.getUser().getEmail().equals(userEmail);
+    }
+
+    private static boolean isDeleted(Group group) {
+        return group.getIsDeleted();
     }
 }

--- a/src/main/java/com/map/gaja/group/infrastructure/GroupQueryRepository.java
+++ b/src/main/java/com/map/gaja/group/infrastructure/GroupQueryRepository.java
@@ -56,20 +56,16 @@ public class GroupQueryRepository {
     }
 
     /**
-     * 해당 Email의 User가 그룹을 가지고 있는지 확인
+     * 해당 Group과 연관된 User를 함께 가져옴
      * @param groupId 그룹 ID
-     * @param userEmail User Email
-     * @return 가지고 있다면 true
+     * @return 찾은 Group 반환
      */
-    public Optional<Group> findGroupByUser(Long groupId, String userEmail) {
+    public Optional<Group> findGroupWithUser(Long groupId) {
         Group result = query.selectFrom(group)
                 .join(group.user, user)
                 .where(group.id.eq(groupId))
                 .fetchJoin().fetchOne();
 
-        if(result != null && result.getUser() != null && result.getUser().getEmail().equals(userEmail))
-            return Optional.ofNullable(result);
-
-        return Optional.ofNullable(null);
+        return Optional.ofNullable(result);
     }
 }

--- a/src/main/java/com/map/gaja/group/infrastructure/GroupQueryRepository.java
+++ b/src/main/java/com/map/gaja/group/infrastructure/GroupQueryRepository.java
@@ -44,14 +44,15 @@ public class GroupQueryRepository {
 
 
     /**
-     * 해당 Email의 User가 가지고 있는 그룹 ID 반환
+     * 해당 Email의 User가 가지고 있는 "삭제되지 않은" 그룹 ID 반환
      * @param userEmail 로그인한 Email
      * @return 가지고 있는 그룹의 ID List
      */
-    public List<Long> findGroupId(String userEmail) {
+    public List<Long> findActiveGroup(String userEmail) {
         return query.select(group.id)
                 .from(group)
                 .join(group.user, user).on(user.email.eq(userEmail))
+                .where(group.isDeleted.eq(Boolean.FALSE))
                 .fetch();
     }
 

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
@@ -21,7 +21,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -184,7 +183,7 @@ class ClientQueryRepositoryTest {
     void ss() {
         String nameCond = "사용자";
 
-        List<ClientResponse> result = clientQueryRepository.findAllClientByEmail(user.getEmail(), nameCond);
+        List<ClientResponse> result = clientQueryRepository.findActiveClientByEmail(user.getEmail(), nameCond);
 
         assertThat(result.size()).isEqualTo(group1ClientList.size() + group2ClientList.size());
         result.forEach((client) -> {

--- a/src/test/java/com/map/gaja/group/application/GroupAccessVerifyServiceTest.java
+++ b/src/test/java/com/map/gaja/group/application/GroupAccessVerifyServiceTest.java
@@ -1,15 +1,15 @@
 package com.map.gaja.group.application;
 
+import com.map.gaja.group.domain.exception.GroupNotFoundException;
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.group.infrastructure.GroupQueryRepository;
 import com.map.gaja.user.domain.model.User;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -26,6 +26,7 @@ class GroupAccessVerifyServiceTest {
 
     @InjectMocks
     GroupAccessVerifyService groupAccessVerifyService;
+
     @Test
     @DisplayName("그룹 접근 확인")
     void verifyGroupAccess() {
@@ -34,12 +35,45 @@ class GroupAccessVerifyServiceTest {
         User user = User.builder()
                 .id(1L).email(email).referenceGroupId(null).build();
         Group group = Group.builder()
-                .id(groupId).user(user).build();
-        when(groupQueryRepository.findGroupByUser(anyLong(), anyString()))
+                .id(groupId).user(user).isDeleted(false).build();
+        when(groupQueryRepository.findGroupWithUser(anyLong()))
                 .thenReturn(Optional.ofNullable(group));
 
         groupAccessVerifyService.verifyGroupAccess(groupId, email);
 
         assertThat(user.getReferenceGroupId()).isEqualTo(groupId);
+    }
+
+    @Test
+    @DisplayName("삭제된 그룹 접근")
+    void verifyDeletedGroup() {
+        Long groupId = 2L;
+        String email = "test@example.com";
+        User user = User.builder()
+                .id(1L).email(email).referenceGroupId(null).build();
+        Group group = Group.builder()
+                .id(groupId).user(user).isDeleted(true).build();
+        when(groupQueryRepository.findGroupWithUser(anyLong()))
+                .thenReturn(Optional.ofNullable(group));
+
+        assertThrows(GroupNotFoundException.class,
+                () -> groupAccessVerifyService.verifyGroupAccess(groupId, email));
+    }
+
+    @Test
+    @DisplayName("삭제된 그룹 접근")
+    void verifyMismatchUserEmail() {
+        Long groupId = 2L;
+        String email = "test@example.com";
+        String mismatchingEmail = "exam@example.com";
+        User user = User.builder()
+                .id(1L).email(email).referenceGroupId(null).build();
+        Group group = Group.builder()
+                .id(groupId).user(user).isDeleted(true).build();
+        when(groupQueryRepository.findGroupWithUser(anyLong()))
+                .thenReturn(Optional.ofNullable(group));
+
+        assertThrows(GroupNotFoundException.class,
+                () -> groupAccessVerifyService.verifyGroupAccess(groupId, mismatchingEmail));
     }
 }


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #187 

<!--
 전달할 내용
-->
## comment
- 모든 로직에서 isDelete를 Where문에 추가해서 추가적으로 필터링하는게 좀 아까운거 같아서.
/group/{groupId}/clients 이렇게 들어오는 곳은 그룹 접근 권한 검사에서 delete 유무를 파악하고,
쿼리문에서는 그냥 검색하도록 만듦

/clients 와 같은 전체 그룹에서 검색하는 곳에서는 접근 권한 검사를 할 수 없음.
그렇기 때문에 이 부분에서만 쿼리를 할 때 Group의 delete 유무를 검사하도록 만듦

<!--
 참고한 사이트
-->
## References
- 