### PR TITLE
Feat/#209 client 이미지 prefix를 알 수 있도록 Response 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -25,7 +25,7 @@ import java.util.List;
  * Request -> Entity 또는 Entity -> Response 컨버터
  */
 public class ClientConvertor {
-    protected static ClientListResponse entityToDto(List<Client> clients) {
+    protected static ClientListResponse entityToDto(List<Client> clients, S3UrlGenerator s3UrlGenerator) {
         List<ClientOverviewResponse> responseClients = new ArrayList<>();
 
         clients.forEach(client -> {
@@ -33,7 +33,7 @@ public class ClientConvertor {
             responseClients.add(clientResponse);
         });
 
-        return new ClientListResponse(responseClients);
+        return new ClientListResponse(responseClients, s3UrlGenerator.getS3Url());
     }
 
     protected static ClientDetailResponse entityToDetailDto(Client client, S3UrlGenerator s3UrlGenerator) {

--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -29,7 +29,7 @@ public class ClientConvertor {
         List<ClientOverviewResponse> responseClients = new ArrayList<>();
 
         clients.forEach(client -> {
-            ClientOverviewResponse clientResponse = entityToDto(client);
+            ClientOverviewResponse clientResponse = entityToOverviewDto(client);
             responseClients.add(clientResponse);
         });
 
@@ -50,7 +50,7 @@ public class ClientConvertor {
         );
     }
 
-    protected static ClientOverviewResponse entityToDto(Client client) {
+    protected static ClientOverviewResponse entityToOverviewDto(Client client) {
         return new ClientOverviewResponse(
                 client.getId(),
                 new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),

--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -13,7 +13,7 @@ import com.map.gaja.client.presentation.dto.request.NewClientRequest;
 import com.map.gaja.client.presentation.dto.request.subdto.AddressDto;
 import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 
 import java.util.ArrayList;
@@ -24,18 +24,18 @@ import java.util.List;
  */
 public class ClientConvertor {
     protected static ClientListResponse entityToDto(List<Client> clients) {
-        List<ClientResponse> responseClients = new ArrayList<>();
+        List<ClientOverviewResponse> responseClients = new ArrayList<>();
 
         clients.forEach(client -> {
-            ClientResponse clientResponse = entityToDto(client);
+            ClientOverviewResponse clientResponse = entityToDto(client);
             responseClients.add(clientResponse);
         });
 
         return new ClientListResponse(responseClients);
     }
 
-    protected static ClientResponse entityToDto(Client client) {
-        return new ClientResponse(
+    protected static ClientOverviewResponse entityToDto(Client client) {
+        return new ClientOverviewResponse(
                 client.getId(),
                 new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),
                 client.getName(),

--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -1,7 +1,9 @@
 package com.map.gaja.client.apllication;
 
 import com.map.gaja.client.infrastructure.file.excel.ClientExcelData;
+import com.map.gaja.client.infrastructure.s3.S3UrlGenerator;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleNewClientRequest;
+import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.client.domain.model.Client;
@@ -34,6 +36,20 @@ public class ClientConvertor {
         return new ClientListResponse(responseClients);
     }
 
+    protected static ClientDetailResponse entityToDetailDto(Client client, S3UrlGenerator s3UrlGenerator) {
+        StoredFileDto image = getStoredFileUrlDto(client.getClientImage(), s3UrlGenerator);
+        return new ClientDetailResponse(
+                client.getId(),
+                new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),
+                client.getName(),
+                client.getPhoneNumber(),
+                voToDto(client.getAddress()),
+                voToDto(client.getLocation()),
+                image,
+                null
+        );
+    }
+
     protected static ClientOverviewResponse entityToDto(Client client) {
         return new ClientOverviewResponse(
                 client.getId(),
@@ -42,7 +58,7 @@ public class ClientConvertor {
                 client.getPhoneNumber(),
                 voToDto(client.getAddress()),
                 voToDto(client.getLocation()),
-                (client.getClientImage() == null) ? new StoredFileDto() : new StoredFileDto(client.getClientImage().getSavedPath(), client.getClientImage().getOriginalName()),
+                getStoredFileDto(client.getClientImage()),
                 null
         );
     }
@@ -117,5 +133,19 @@ public class ClientConvertor {
                 new AddressDto(address.getProvince(), address.getCity(), address.getDistrict(), address.getDetail());
     }
 
+
+    private static StoredFileDto getStoredFileUrlDto(ClientImage clientImage, S3UrlGenerator s3UrlGenerator) {
+        if (clientImage == null) {
+            return new StoredFileDto();
+        }
+        else {
+            String imageUrl = s3UrlGenerator.getS3Url() + clientImage.getSavedPath();
+            return new StoredFileDto(imageUrl, clientImage.getOriginalName());
+        }
+    }
+
+    private static StoredFileDto getStoredFileDto(ClientImage clientImage) {
+        return (clientImage == null) ? new StoredFileDto() : new StoredFileDto(clientImage.getSavedPath(), clientImage.getOriginalName());
+    }
 
 }

--- a/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
@@ -8,7 +8,7 @@ import com.map.gaja.client.infrastructure.repository.ClientQueryRepository;
 import com.map.gaja.client.infrastructure.repository.ClientRepository;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
@@ -28,7 +28,7 @@ public class ClientQueryService {
     private final ClientQueryRepository clientQueryRepository;
     private final GroupQueryRepository groupQueryRepository;
 
-    public ClientResponse findClient(Long clientId) {
+    public ClientOverviewResponse findClient(Long clientId) {
         Client client = clientQueryRepository.findClientWithGroup(clientId)
                 .orElseThrow(() -> new ClientNotFoundException());
         return entityToDto(client);
@@ -43,12 +43,12 @@ public class ClientQueryService {
         List<Long> groupIdList = new ArrayList<>();
         groupIdList.add(groupId);
 
-        List<ClientResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
+        List<ClientOverviewResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
         return new ClientListResponse(clientList);
     }
 
     public StoredFileDto findClientImage(Long clientId) {
-        ClientResponse client = findClient(clientId);
+        ClientOverviewResponse client = findClient(clientId);
         return client.getImage();
     }
 
@@ -56,7 +56,7 @@ public class ClientQueryService {
             String loginEmail,
             @Nullable String nameCond
     ) {
-        List<ClientResponse> clientList = clientQueryRepository.findActiveClientByEmail(loginEmail, nameCond);
+        List<ClientOverviewResponse> clientList = clientQueryRepository.findActiveClientByEmail(loginEmail, nameCond);
         return new ClientListResponse(clientList);
     }
 
@@ -66,7 +66,7 @@ public class ClientQueryService {
             throw new GroupNotFoundException();
         }
 
-        List<ClientResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
+        List<ClientOverviewResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
         return new ClientListResponse(clientList);
     }
 }

--- a/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
@@ -26,7 +26,6 @@ import static com.map.gaja.client.apllication.ClientConvertor.*;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ClientQueryService {
-    private final ClientRepository clientRepository;
     private final ClientQueryRepository clientQueryRepository;
     private final GroupQueryRepository groupQueryRepository;
     private final S3UrlGenerator s3UrlGenerator;
@@ -39,7 +38,7 @@ public class ClientQueryService {
 
     public ClientListResponse findAllClientsInGroup(Long groupId, @Nullable String wordCond) {
         List<Client> clients = clientQueryRepository.findByGroup_Id(groupId, wordCond);
-        return entityToDto(clients);
+        return entityToDto(clients, s3UrlGenerator);
     }
 
     public ClientListResponse findClientByConditions(Long groupId, NearbyClientSearchRequest locationSearchCond, String wordCond) {
@@ -47,7 +46,7 @@ public class ClientQueryService {
         groupIdList.add(groupId);
 
         List<ClientOverviewResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
-        return new ClientListResponse(clientList);
+        return new ClientListResponse(clientList, s3UrlGenerator.getS3Url());
     }
 
     public StoredFileDto findClientImage(Long clientId) {
@@ -60,7 +59,7 @@ public class ClientQueryService {
             @Nullable String nameCond
     ) {
         List<ClientOverviewResponse> clientList = clientQueryRepository.findActiveClientByEmail(loginEmail, nameCond);
-        return new ClientListResponse(clientList);
+        return new ClientListResponse(clientList, s3UrlGenerator.getS3Url());
     }
 
     public ClientListResponse findClientByConditions(String loginEmail, NearbyClientSearchRequest locationSearchCond, String wordCond) {
@@ -70,6 +69,6 @@ public class ClientQueryService {
         }
 
         List<ClientOverviewResponse> clientList = clientQueryRepository.findClientByConditions(groupIdList, locationSearchCond, wordCond);
-        return new ClientListResponse(clientList);
+        return new ClientListResponse(clientList, s3UrlGenerator.getS3Url());
     }
 }

--- a/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientQueryService.java
@@ -1,5 +1,7 @@
 package com.map.gaja.client.apllication;
 
+import com.map.gaja.client.infrastructure.s3.S3UrlGenerator;
+import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.map.gaja.group.domain.exception.GroupNotFoundException;
 import com.map.gaja.group.infrastructure.GroupQueryRepository;
@@ -27,11 +29,12 @@ public class ClientQueryService {
     private final ClientRepository clientRepository;
     private final ClientQueryRepository clientQueryRepository;
     private final GroupQueryRepository groupQueryRepository;
+    private final S3UrlGenerator s3UrlGenerator;
 
-    public ClientOverviewResponse findClient(Long clientId) {
+    public ClientDetailResponse findClient(Long clientId) {
         Client client = clientQueryRepository.findClientWithGroup(clientId)
                 .orElseThrow(() -> new ClientNotFoundException());
-        return entityToDto(client);
+        return entityToDetailDto(client, s3UrlGenerator);
     }
 
     public ClientListResponse findAllClientsInGroup(Long groupId, @Nullable String wordCond) {
@@ -48,7 +51,7 @@ public class ClientQueryService {
     }
 
     public StoredFileDto findClientImage(Long clientId) {
-        ClientOverviewResponse client = findClient(clientId);
+        ClientDetailResponse client = findClient(clientId);
         return client.getImage();
     }
 

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -4,7 +4,7 @@ import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.infrastructure.repository.querydsl.sql.NativeSqlCreator;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.request.subdto.AddressDto;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
@@ -44,13 +44,13 @@ public class ClientQueryRepository {
      * @param wordCond
      * @return
      */
-    public List<ClientResponse> findClientByConditions(List<Long> groupIdList, NearbyClientSearchRequest locationSearchCond, @Nullable String wordCond) {
+    public List<ClientOverviewResponse> findClientByConditions(List<Long> groupIdList, NearbyClientSearchRequest locationSearchCond, @Nullable String wordCond) {
         if (groupIdList.size() < 1) {
             return new ArrayList<>();
         }
 
-        List<ClientResponse> result = query.select(
-                        Projections.constructor(ClientResponse.class,
+        List<ClientOverviewResponse> result = query.select(
+                        Projections.constructor(ClientOverviewResponse.class,
                                 client.id,
                                 Projections.constructor(GroupInfoDto.class, client.group.id, client.group.name),
                                 client.name,
@@ -167,10 +167,10 @@ public class ClientQueryRepository {
      * @param nameCond 이름 검색 조건
      * @return
      */
-    public List<ClientResponse> findActiveClientByEmail(String loginEmail, @Nullable String nameCond) {
-        List<ClientResponse> result = query
+    public List<ClientOverviewResponse> findActiveClientByEmail(String loginEmail, @Nullable String nameCond) {
+        List<ClientOverviewResponse> result = query
                 .select(
-                        Projections.constructor(ClientResponse.class,
+                        Projections.constructor(ClientOverviewResponse.class,
                                 client.id,
                                 Projections.constructor(GroupInfoDto.class, client.group.id, client.group.name),
                                 client.name,

--- a/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
@@ -7,7 +7,7 @@ import com.map.gaja.client.apllication.ClientQueryService;
 import com.map.gaja.client.presentation.dto.ClientAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,7 +29,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
     private final GroupAccessVerifyService groupAccessVerifyService;
 
     @GetMapping("/api/group/{groupId}/clients/{clientId}")
-    public ResponseEntity<ClientResponse> getClient(
+    public ResponseEntity<ClientOverviewResponse> getClient(
             @AuthenticationPrincipal String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId
@@ -37,7 +37,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
         // 거래처 조회
         log.info("ClientController.getClient clientId={}", clientId);
         verifyClientAccess(loginEmail,groupId,clientId);
-        ClientResponse response = clientQueryService.findClient(clientId);
+        ClientOverviewResponse response = clientQueryService.findClient(clientId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
@@ -1,13 +1,13 @@
 package com.map.gaja.client.presentation.api;
 
 import com.map.gaja.client.presentation.api.specification.GroupClientQueryApiSpecification;
+import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.group.application.GroupAccessVerifyService;
 import com.map.gaja.client.apllication.ClientAccessVerifyService;
 import com.map.gaja.client.apllication.ClientQueryService;
 import com.map.gaja.client.presentation.dto.ClientAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
-import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -29,7 +29,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
     private final GroupAccessVerifyService groupAccessVerifyService;
 
     @GetMapping("/api/group/{groupId}/clients/{clientId}")
-    public ResponseEntity<ClientOverviewResponse> getClient(
+    public ResponseEntity<ClientDetailResponse> getClient(
             @AuthenticationPrincipal String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId
@@ -37,7 +37,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
         // 거래처 조회
         log.info("ClientController.getClient clientId={}", clientId);
         verifyClientAccess(loginEmail,groupId,clientId);
-        ClientOverviewResponse response = clientQueryService.findClient(clientId);
+        ClientDetailResponse response = clientQueryService.findClient(clientId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/GroupClientQueryApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/GroupClientQueryApiSpecification.java
@@ -1,6 +1,7 @@
 package com.map.gaja.client.presentation.api.specification;
 
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
+import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
 import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.global.exception.ExceptionDto;
@@ -30,7 +31,7 @@ public interface GroupClientQueryApiSpecification {
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
     @GetMapping("/api/group/{groupId}/clients/{clientId}")
-    public ResponseEntity<ClientOverviewResponse> getClient(
+    public ResponseEntity<ClientDetailResponse> getClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/GroupClientQueryApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/GroupClientQueryApiSpecification.java
@@ -2,7 +2,7 @@ package com.map.gaja.client.presentation.api.specification;
 
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.global.exception.ExceptionDto;
 import com.map.gaja.global.exception.ValidationErrorInfo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,11 +26,11 @@ public interface GroupClientQueryApiSpecification {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
             },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientResponse.class))),
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 번들이 없거나, 번들에 요청 고객이 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
             })
     @GetMapping("/api/group/{groupId}/clients/{clientId}")
-    public ResponseEntity<ClientResponse> getClient(
+    public ResponseEntity<ClientOverviewResponse> getClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId

--- a/src/main/java/com/map/gaja/client/presentation/dto/response/ClientDetailResponse.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/response/ClientDetailResponse.java
@@ -5,10 +5,16 @@ import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Client 상세보기 Data
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ClientDetailResponse {
     @Schema(description = "고객 등록 ID 번호", example = "111")
     private Long clientId;

--- a/src/main/java/com/map/gaja/client/presentation/dto/response/ClientDetailResponse.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/response/ClientDetailResponse.java
@@ -1,0 +1,46 @@
+package com.map.gaja.client.presentation.dto.response;
+
+import com.map.gaja.client.presentation.dto.request.subdto.AddressDto;
+import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
+import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
+import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Client 상세보기 Data
+ */
+public class ClientDetailResponse {
+    @Schema(description = "고객 등록 ID 번호", example = "111")
+    private Long clientId;
+
+    @Schema(description = "고객이 속한 그룹")
+    private GroupInfoDto groupInfo;
+
+    @Schema(description = "고객 이름", example = "홍길동")
+    private String clientName;
+
+    @Schema(description = "고객 전화번호", example = "010-3333-4444")
+    private String phoneNumber;
+
+    @Schema(description = "고객 주소")
+    private AddressDto address;
+
+    @Schema(description = "고객 위치")
+    private LocationDto location;
+
+    @Schema(description = "고객 사진")
+    private StoredFileDto image;
+
+    @Schema(description = "현재 위치에서 떨어진 거리(M - 미터)", example = "2398")
+    private Double distance; // km 기준
+
+    public ClientDetailResponse(Long clientId, GroupInfoDto groupInfo, String clientName, String phoneNumber, AddressDto address, LocationDto location, StoredFileDto image) {
+        this.clientId = clientId;
+        this.groupInfo = groupInfo;
+        this.clientName = clientName;
+        this.phoneNumber = phoneNumber;
+        this.address = address;
+        this.location = location;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/map/gaja/client/presentation/dto/response/ClientListResponse.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/response/ClientListResponse.java
@@ -13,5 +13,5 @@ import java.util.List;
 @AllArgsConstructor
 public class ClientListResponse {
     @Schema(description = "고객 리스트")
-    List<ClientResponse> clients;
+    List<ClientOverviewResponse> clients;
 }

--- a/src/main/java/com/map/gaja/client/presentation/dto/response/ClientListResponse.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/response/ClientListResponse.java
@@ -14,4 +14,7 @@ import java.util.List;
 public class ClientListResponse {
     @Schema(description = "고객 리스트")
     List<ClientOverviewResponse> clients;
+
+    @Schema(description = "고객 이미지 url 앞부분 client.image.filePath 앞 부분에 추가해서 \"https://버킷이름.s3.지역.amazonaws.com/uuid.png\"로사용하세요.", example = "https://버킷이름.s3.지역.amazonaws.com/")
+    String imageUrlPrefix;
 }

--- a/src/main/java/com/map/gaja/client/presentation/dto/response/ClientOverviewResponse.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/response/ClientOverviewResponse.java
@@ -1,7 +1,5 @@
 package com.map.gaja.client.presentation.dto.response;
 
-import com.map.gaja.client.domain.model.ClientAddress;
-import com.map.gaja.client.domain.model.ClientLocation;
 import com.map.gaja.client.presentation.dto.request.subdto.AddressDto;
 import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
@@ -15,10 +13,9 @@ import lombok.*;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class ClientResponse {
+public class ClientOverviewResponse {
     @Schema(description = "고객 등록 ID 번호", example = "111")
     private Long clientId;
-//    private Long groupId;
     @Schema(description = "고객이 속한 그룹")
     private GroupInfoDto groupInfo;
     @Schema(description = "고객 이름", example = "홍길동")
@@ -34,7 +31,7 @@ public class ClientResponse {
     @Schema(description = "현재 위치에서 떨어진 거리(M - 미터)", example = "2398")
     private Double distance; // km 기준
 
-    public ClientResponse(Long clientId, GroupInfoDto groupInfo, String clientName, String phoneNumber, AddressDto address, LocationDto location, StoredFileDto image) {
+    public ClientOverviewResponse(Long clientId, GroupInfoDto groupInfo, String clientName, String phoneNumber, AddressDto address, LocationDto location, StoredFileDto image) {
         this.clientId = clientId;
         this.groupInfo = groupInfo;
         this.clientName = clientName;

--- a/src/test/java/com/map/gaja/client/apllication/ClientQueryServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientQueryServiceTest.java
@@ -2,6 +2,8 @@ package com.map.gaja.client.apllication;
 
 import com.map.gaja.client.domain.model.ClientImage;
 import com.map.gaja.client.infrastructure.repository.ClientQueryRepository;
+import com.map.gaja.client.infrastructure.s3.S3UrlGenerator;
+import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.domain.model.ClientAddress;
@@ -25,6 +27,9 @@ class ClientQueryServiceTest {
     @Mock
     private ClientQueryRepository repository;
 
+    @Mock
+    private S3UrlGenerator s3UrlGenerator;
+
     @InjectMocks
     private ClientQueryService clientQueryService;
 
@@ -41,14 +46,19 @@ class ClientQueryServiceTest {
         when(findClient.getAddress()).thenReturn(new ClientAddress());
         when(findClient.getLocation()).thenReturn(new ClientLocation());
         when(findClient.getGroup()).thenReturn(Group.builder().id(groupId).build());
-        when(findClient.getClientImage()).thenReturn(new ClientImage("testImage", "testImage"));
+
+        String urlPrefix = "s3.aaa.bbb/";
+        String savedPath = "testImage";
+        when(findClient.getClientImage()).thenReturn(new ClientImage("testImage", savedPath));
+        when(s3UrlGenerator.getS3Url()).thenReturn(urlPrefix);
 
         //when
-        ClientOverviewResponse response = clientQueryService.findClient(searchId);
+        ClientDetailResponse response = clientQueryService.findClient(searchId);
 
         //then
         assertThat(response.getClientId()).isEqualTo(searchId);
         assertThat(response.getClientName()).isEqualTo(searchName);
+        assertThat(response.getImage().getFilePath()).isEqualTo(urlPrefix + savedPath);
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/apllication/ClientQueryServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientQueryServiceTest.java
@@ -6,7 +6,7 @@ import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.domain.model.ClientAddress;
 import com.map.gaja.client.domain.model.ClientLocation;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +44,7 @@ class ClientQueryServiceTest {
         when(findClient.getClientImage()).thenReturn(new ClientImage("testImage", "testImage"));
 
         //when
-        ClientResponse response = clientQueryService.findClient(searchId);
+        ClientOverviewResponse response = clientQueryService.findClient(searchId);
 
         //then
         assertThat(response.getClientId()).isEqualTo(searchId);

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepositoryTest.java
@@ -5,7 +5,7 @@ import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.domain.model.ClientAddress;
 import com.map.gaja.client.domain.model.ClientLocation;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
-import com.map.gaja.client.presentation.dto.response.ClientResponse;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.user.domain.model.Authority;
 import com.map.gaja.user.domain.model.User;
@@ -111,7 +111,7 @@ class ClientQueryRepositoryTest {
         List<Long> groupIdList = new ArrayList<>();
         groupIdList.add(groupId);
 
-        List<ClientResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request,nameKeyword);
+        List<ClientOverviewResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request,nameKeyword);
 
         assertThat(result.size()).isEqualTo(group2ClientList.size());
         double beforeDistance = -1;
@@ -140,7 +140,7 @@ class ClientQueryRepositoryTest {
         groupIdList.add(groupId1);
         groupIdList.add(groupId2);
 
-        List<ClientResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request,nameKeyword);
+        List<ClientOverviewResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request,nameKeyword);
 
         assertThat(result.size()).isEqualTo(group1ClientList.size() + group2ClientList.size());
         result.forEach((client) -> {
@@ -183,7 +183,7 @@ class ClientQueryRepositoryTest {
     void ss() {
         String nameCond = "사용자";
 
-        List<ClientResponse> result = clientQueryRepository.findActiveClientByEmail(user.getEmail(), nameCond);
+        List<ClientOverviewResponse> result = clientQueryRepository.findActiveClientByEmail(user.getEmail(), nameCond);
 
         assertThat(result.size()).isEqualTo(group1ClientList.size() + group2ClientList.size());
         result.forEach((client) -> {


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #209 

<!--
 전달할 내용
-->
## comment
- 리스트 형식으로 Overview를 확인할 시
![image](https://github.com/GaJaMap/backend/assets/88225377/a06595aa-15ed-44a3-b6ce-dfa7861b4a8c)

- 특정 ClientID로 직접 조회 시
![image](https://github.com/GaJaMap/backend/assets/88225377/525e7166-d649-49e2-8be5-4ee4252eb7f3)


특정 ClientID로 조회 시에 `ClientDetailResponse`를 반환. -  `image.filePath`가 전체 경로로 변경된다.
리스트 형식으로 Client 조회 시에 `ClientOverviewResponse`를 반환. - `imageUrlPrefix`가 추가적인 정보로 반환된다.

<!--
 참고한 사이트
-->
## References
- 