### PR TITLE
feat: 카카오 웹 oauth2 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	implementation group: 'org.apache.poi', name: 'poi', version: '5.2.2'
 	implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.2'
 
+	// oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -36,7 +36,7 @@ public class ClientController implements ClientCommandApiSpecification {
 
     @DeleteMapping("/group/{groupId}/clients/{clientId}")
     public ResponseEntity<Void> deleteClient(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId
     ) {
@@ -56,7 +56,7 @@ public class ClientController implements ClientCommandApiSpecification {
 
     @PutMapping("/group/{groupId}/clients/{clientId}")
     public ResponseEntity<Void> updateClient(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId,
             @Valid @ModelAttribute NewClientRequest clientRequest
@@ -99,7 +99,7 @@ public class ClientController implements ClientCommandApiSpecification {
 
     @PostMapping("/clients/bulk")
     public ResponseEntity<List<Long>> addSimpleBulkClient(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @Valid @RequestBody SimpleClientBulkRequest clientBulkRequest
     ) {
         // 단순한 Client 정보 등록
@@ -110,7 +110,7 @@ public class ClientController implements ClientCommandApiSpecification {
 
     @PostMapping("/clients")
     public ResponseEntity<Long> addClient(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @Valid @ModelAttribute NewClientRequest clientRequest
     ) {
         // 거래처 등록 - 단건 등록

--- a/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
@@ -23,7 +23,7 @@ public class GetClientController implements ClientQueryApiSpecification {
 
     @GetMapping("/nearby")
     public ResponseEntity<ClientListResponse> nearbyClientSearch(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @Valid @ModelAttribute NearbyClientSearchRequest locationSearchCond,
             @RequestParam(required = false) String wordCond
     ) {
@@ -35,7 +35,7 @@ public class GetClientController implements ClientQueryApiSpecification {
 
     @GetMapping
     public ResponseEntity<ClientListResponse> getAllClients(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @RequestParam(required = false) String wordCond
     ) {
         // 사용자가 가지고 있는 전체 고객 조회

--- a/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
@@ -30,7 +30,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
 
     @GetMapping("/api/group/{groupId}/clients/{clientId}")
     public ResponseEntity<ClientResponse> getClient(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId
     ) {
@@ -43,7 +43,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
 
     @GetMapping("/api/group/{groupId}/clients")
     public ResponseEntity<ClientListResponse> getClientList(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,
             @RequestParam(required = false) String wordCond
     ) {
@@ -56,7 +56,7 @@ public class GetGroupClientController implements GroupClientQueryApiSpecificatio
 
     @GetMapping("/api/group/{groupId}/clients/nearby")
     public ResponseEntity<ClientListResponse> nearbyClientSearch(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,
             @Valid @ModelAttribute NearbyClientSearchRequest locationSearchCond,
             @RequestParam(required = false) String wordCond

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -38,7 +38,7 @@ public class WebClientController {
     ) {
         // 로그인이 안된 사용자
         if (authentication == null) {
-            return "redirect:/oauth2/authorization/kakao";
+            return "redirect:/login";
         }
 
         String email = authentication.getName(); //이메일

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -52,7 +52,7 @@ public class WebClientController {
     @PostMapping("/api/clients/file")
     @ResponseBody
     public ResponseEntity<Void> clientUpload(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal(expression = "name") String loginEmail,
             ClientExcelRequest excelRequest
     ) {
         FileValidator.verifyFile(excelRequest.getExcelFile());

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -6,12 +6,14 @@ import com.map.gaja.client.infrastructure.file.excel.ClientExcelData;
 import com.map.gaja.client.infrastructure.file.excel.ExcelParser;
 import com.map.gaja.client.presentation.dto.request.ClientExcelRequest;
 import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
+import com.map.gaja.global.authentication.PrincipalDetails;
 import com.map.gaja.group.application.GroupAccessVerifyService;
 import com.map.gaja.group.application.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +21,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
-import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -32,15 +33,17 @@ public class WebClientController {
 
     @GetMapping("/")
     public String clientFileUpload(
-            @AuthenticationPrincipal String loginEmail,
+            @AuthenticationPrincipal PrincipalDetails authentication,
             Model model
     ) {
         // 로그인이 안된 사용자
-        if (loginEmail.equals("anonymousUser")) {
-            return "redirect:/login";
+        if (authentication == null) {
+            return "redirect:/oauth2/authorization/kakao";
         }
 
-        List<GroupInfoDto> activeGroupInfo = groupService.findActiveGroupInfo(loginEmail);
+        String email = authentication.getName(); //이메일
+
+        List<GroupInfoDto> activeGroupInfo = groupService.findActiveGroupInfo(email);
         model.addAttribute("groupList", activeGroupInfo);
 
         return "index";

--- a/src/main/java/com/map/gaja/global/authentication/AuthenticationHandler.java
+++ b/src/main/java/com/map/gaja/global/authentication/AuthenticationHandler.java
@@ -1,16 +1,19 @@
 package com.map.gaja.global.authentication;
 
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AuthenticationHandler {
     public void saveContext(String email, String authority) {
-        Authentication token = new AuthenticationToken(email, authority);
+        UserDetails userDetails = new PrincipalDetails(email, authority);
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        context.setAuthentication(token);
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities()));
         SecurityContextHolder.setContext(context);
     }
+
 }

--- a/src/main/java/com/map/gaja/global/authentication/PrincipalDetails.java
+++ b/src/main/java/com/map/gaja/global/authentication/PrincipalDetails.java
@@ -1,0 +1,77 @@
+package com.map.gaja.global.authentication;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class PrincipalDetails implements UserDetails, OAuth2User {
+    private String email;
+    private String authority;
+    private Map<String, Object> attributes;
+
+    public PrincipalDetails(String email, String authority) {
+        this.email = email;
+        this.authority = authority;
+    }
+
+    public PrincipalDetails(String email, String authority, Map<String, Object> attributes) {
+        this.email = email;
+        this.authority = authority;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> role = new ArrayList<>();
+
+        role.add((GrantedAuthority) () -> authority);
+
+        return role;
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/map/gaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
@@ -20,8 +21,8 @@ public class SecurityConfig {
         http
                 .httpBasic().disable()
                 .authorizeHttpRequests(request -> request
-                        .antMatchers("/api/**").permitAll()
-                        .antMatchers("/").permitAll()) // 엑셀 페이지 설정
+                        .antMatchers("/", "/api/user/login").permitAll()
+                        .anyRequest().authenticated()) // 엑셀 페이지 설정
                 .csrf().disable()
                 .formLogin().disable()
                 .oauth2Login()
@@ -34,4 +35,5 @@ public class SecurityConfig {
 
         return http.build();
     }
+
 }

--- a/src/main/java/com/map/gaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SecurityConfig.java
@@ -1,21 +1,36 @@
 package com.map.gaja.global.config;
 
+import com.map.gaja.oauth2.application.Oauth2UserService;
+import com.map.gaja.oauth2.handler.Oauth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final Oauth2UserService oauth2UserService;
+    private final Oauth2SuccessHandler oauth2SuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .httpBasic().disable()
                 .authorizeHttpRequests(request -> request
                         .antMatchers("/api/**").permitAll()
                         .antMatchers("/").permitAll()) // 엑셀 페이지 설정
                 .csrf().disable()
-                .formLogin().disable();
+                .formLogin().disable()
+                .oauth2Login()
+                    .userInfoEndpoint().userService(oauth2UserService) //oauth2 로그인 후 처리 로직
+                .and()
+                .successHandler(oauth2SuccessHandler) //웹에서 oauth2 로그인 성공할 경우
+                .and()
+                .exceptionHandling()
+                    .authenticationEntryPoint(new Http403ForbiddenEntryPoint()); //인증되지 없을 경우 로그인 창으로 이동하는데 앱에서는 403으로 응답해주기 위해서 403으로 통일함
 
         return http.build();
     }

--- a/src/main/java/com/map/gaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SecurityConfig.java
@@ -36,4 +36,28 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web
+                .ignoring()
+                .antMatchers(getPathInSwagger());
+    }
+
+    private String[] getPathInSwagger() {
+        return new String[]{
+                "/swagger",
+                "/swagger-ui/index.html",
+                "/swagger-ui/swagger-ui.css",
+                "/swagger-ui/index.css",
+                "/swagger-ui/swagger-ui-bundle.js",
+                "/swagger-ui/swagger-ui-standalone-preset.js",
+                "/swagger-ui/swagger-initializer.js",
+                "/v3/api-docs/swagger-config",
+                "/swagger-ui/favicon-32x32.png",
+                "/v3/api-docs/user-api",
+                "/v3/api-docs/group-api",
+                "/v3/api-docs/client-api",
+                "/favicon.ico"
+        };
+    }
 }

--- a/src/main/java/com/map/gaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         http
                 .httpBasic().disable()
                 .authorizeHttpRequests(request -> request
-                        .antMatchers("/", "/api/user/login").permitAll()
+                        .antMatchers("/", "/api/user/login", "/login").permitAll()
                         .anyRequest().authenticated()) // 엑셀 페이지 설정
                 .csrf().disable()
                 .formLogin().disable()

--- a/src/main/java/com/map/gaja/group/presentation/api/GroupController.java
+++ b/src/main/java/com/map/gaja/group/presentation/api/GroupController.java
@@ -25,7 +25,7 @@ public class GroupController implements GroupApiSpecification {
     @Override
     @PostMapping
     public ResponseEntity<Long> create(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal(expression = "name") String email,
             @Valid @RequestBody GroupCreateRequest request
     ) {
         Long groupId = groupService.create(email, request);
@@ -35,7 +35,7 @@ public class GroupController implements GroupApiSpecification {
 
     @Override
     @GetMapping
-    public ResponseEntity<GroupResponse> read(@AuthenticationPrincipal String email, @PageableDefault Pageable pageable) {
+    public ResponseEntity<GroupResponse> read(@AuthenticationPrincipal(expression = "name") String email, @PageableDefault Pageable pageable) {
         GroupResponse response = groupService.findGroups(email, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -43,7 +43,7 @@ public class GroupController implements GroupApiSpecification {
 
     @Override
     @DeleteMapping("/{groupId}")
-    public ResponseEntity<Void> delete(@AuthenticationPrincipal String email, @PathVariable Long groupId) {
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal(expression = "name") String email, @PathVariable Long groupId) {
         groupService.delete(email, groupId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
@@ -51,7 +51,7 @@ public class GroupController implements GroupApiSpecification {
     @Override
     @PutMapping("/{groupId}")
     public ResponseEntity<Void> update(
-            @AuthenticationPrincipal String email,
+            @AuthenticationPrincipal(expression = "name") String email,
             @PathVariable Long groupId,
             @Valid @RequestBody GroupUpdateRequest request
     ) {

--- a/src/main/java/com/map/gaja/oauth2/application/Oauth2UserService.java
+++ b/src/main/java/com/map/gaja/oauth2/application/Oauth2UserService.java
@@ -1,0 +1,49 @@
+package com.map.gaja.oauth2.application;
+
+import com.map.gaja.global.authentication.PrincipalDetails;
+import com.map.gaja.global.authentication.SessionHandler;
+import com.map.gaja.user.domain.model.User;
+import com.map.gaja.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class Oauth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final SessionHandler sessionHandler;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        Map<String, Object> attributes = parseAttributes(userRequest);
+
+        String email = (String) ((Map) attributes.get("kakao_account")).get("email");
+
+        User user = userRepository.findByEmail(email)
+                .orElse(new User(email));
+        userRepository.save(user);
+
+        sessionHandler.deduplicate(email); //중복 세션 제거
+
+        return new PrincipalDetails(user.getEmail(), user.getAuthority().name(), attributes);
+
+    }
+
+    private Map<String, Object> parseAttributes(OAuth2UserRequest userRequest) {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes(); // OAuth 서비스의 유저 정보들
+        return attributes;
+    }
+
+}

--- a/src/main/java/com/map/gaja/oauth2/handler/Oauth2SuccessHandler.java
+++ b/src/main/java/com/map/gaja/oauth2/handler/Oauth2SuccessHandler.java
@@ -1,0 +1,19 @@
+package com.map.gaja.oauth2.handler;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class Oauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Override
+    protected void handle(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        response.sendRedirect("/"); //리다이렉트 경로 입력
+    }
+}

--- a/src/main/java/com/map/gaja/user/presentation/api/UserController.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/UserController.java
@@ -33,7 +33,7 @@ public class UserController implements UserApiSpecification {
 
     @Override
     @DeleteMapping
-    public ResponseEntity<Void> withdrawal(@AuthenticationPrincipal String email, HttpSession session) {
+    public ResponseEntity<Void> withdrawal(@AuthenticationPrincipal(expression = "name") String email, HttpSession session) {
         userService.withdrawal(email);
         session.invalidate();
         return new ResponseEntity<>(HttpStatus.OK);


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #212 

<!--
 전달할 내용
-->
## comment
- 앱과 웹 로그인 인증 객체를 통일해주기 위해서 PrincipalDetails를 구현함

- 시큐리티 접근 권한 permitAll()인 엔드포인트 경우 인증 매개 변수 타입을 _**@AuthencationPrincipal PrincipalDetails details**_ 로 해줘야함. 
 permitAll()이 아닌 경우 **_@AuthenticationPrincipal(expression = "name") String email_** 로 이메일만 받을 수 있음 
**express = "name"** 의미는 PrincipalDetails안에 있는 getName()을 호출해서 값을 받는다는 의미임. 
그래서 permitAll()인 경우 인증 객체가 존재하지 않는데 getName()을 호출하면 에러가 발생해서 PrincipalDetails 타입으로 받음.

- 최초 로그인 시 웹도 로그인시켰음. 예외 핸들링해야 되는데 oauth2로그인이 필터단계에서 처리되는 거라 @ControllerAdvice 에 안 걸러짐. 그래서 oauth2로그인 필터 전 단계에 try-catch를 해서 예외처리를 하든가 다른 방법을 찾아봄

- 카카오 로그인 엔드포인트는 **_/oauth2/authorization/kakao_**

- 웹 첫 페이지를 제외한 모든 api  **_@AuthenticationPrincipal(expression = "name") String email_** 로 수정함

<!--
 참고한 사이트
-->
## References
- 