### PR TITLE
fix: 클라이언트 생성과 삭제에 대한 그룹 내 클라이언트 증감

### DIFF
--- a/src/main/java/com/map/gaja/client/domain/model/Client.java
+++ b/src/main/java/com/map/gaja/client/domain/model/Client.java
@@ -65,7 +65,7 @@ public class Client extends BaseTimeEntity {
     }
 
     public void removeGroup() {
-        group.decreaseClientCount();
+        group.decreaseClientCount(1);
         group = null;
     }
 

--- a/src/main/java/com/map/gaja/client/domain/model/Client.java
+++ b/src/main/java/com/map/gaja/client/domain/model/Client.java
@@ -71,7 +71,7 @@ public class Client extends BaseTimeEntity {
 
     private void setGroup(Group group) {
         this.group = group;
-        group.increaseClientCount();
+        group.increaseClientCount(1);
     }
 
     private void updateGroup(Group group) {

--- a/src/main/java/com/map/gaja/group/domain/exception/ClientNotDeletedException.java
+++ b/src/main/java/com/map/gaja/group/domain/exception/ClientNotDeletedException.java
@@ -1,0 +1,10 @@
+package com.map.gaja.group.domain.exception;
+
+import com.map.gaja.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class ClientNotDeletedException extends BusinessException {
+    public ClientNotDeletedException() {
+        super(HttpStatus.UNPROCESSABLE_ENTITY, "그룹 안에 고객보다 많은 수의 고객을 삭제할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/map/gaja/group/domain/model/Group.java
+++ b/src/main/java/com/map/gaja/group/domain/model/Group.java
@@ -1,6 +1,7 @@
 package com.map.gaja.group.domain.model;
 
 import com.map.gaja.global.auditing.entity.BaseTimeEntity;
+import com.map.gaja.group.domain.exception.ClientNotDeletedException;
 import com.map.gaja.user.domain.model.User;
 import lombok.*;
 
@@ -57,8 +58,11 @@ public class Group extends BaseTimeEntity {
         clientCount += count;
     }
 
-    public void decreaseClientCount(int count) {
-        clientCount -= count;
+    public void decreaseClientCount(int decreaseInCount) {
+        if (clientCount < decreaseInCount) {
+            throw new ClientNotDeletedException();
+        }
+        clientCount -= decreaseInCount;
     }
 
     public void accessGroup() {

--- a/src/main/java/com/map/gaja/group/domain/model/Group.java
+++ b/src/main/java/com/map/gaja/group/domain/model/Group.java
@@ -57,8 +57,8 @@ public class Group extends BaseTimeEntity {
         clientCount += count;
     }
 
-    public void decreaseClientCount() {
-        clientCount--;
+    public void decreaseClientCount(int count) {
+        clientCount -= count;
     }
 
     public void accessGroup() {

--- a/src/main/java/com/map/gaja/group/domain/model/Group.java
+++ b/src/main/java/com/map/gaja/group/domain/model/Group.java
@@ -53,8 +53,8 @@ public class Group extends BaseTimeEntity {
      * Client 클래스 내부에서 사용할 메소드.
      * Client 클래스 내부 이외 호출은 자제.
      */
-    public void increaseClientCount() {
-        clientCount++;
+    public void increaseClientCount(int count) {
+        clientCount += count;
     }
 
     public void decreaseClientCount() {

--- a/src/main/java/com/map/gaja/group/domain/service/IncreasingClientService.java
+++ b/src/main/java/com/map/gaja/group/domain/service/IncreasingClientService.java
@@ -8,12 +8,19 @@ import org.springframework.stereotype.Service;
 @Service
 public class IncreasingClientService {
 
-    public void increase(Group group, Authority authority) {
-        if(authority.getClientLimitCount()<group.getClientCount()){
-            throw new ClientLimitExceededException(authority.name(), group.getClientCount());
+    public void increase(Group group, Authority authority, int count) {
+        if (isCreateClient(authority.getClientLimitCount(), group.getClientCount(), count)) {
+            group.increaseClientCount(count);
+            return;
         }
 
-        group.increaseClientCount();
+        throw new ClientLimitExceededException(authority.name(), group.getClientCount());
     }
 
+    private boolean isCreateClient(int clientLimitCount, int currentClientCount, int increaseInClient) {
+        if (clientLimitCount >= (currentClientCount + increaseInClient)) {
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #219 

<!--
 전달할 내용
-->
## comment
- 생성은 유저 권한확인 때문에 IncreasingClientService 도메인 서비스 사용
- 삭제는 그룹 도메인 하나만 필요하니깐 group.decreaseClientCount(n)호출함
단 삭제에 대한 예외발생도 있으니 api명세서에도 잘 명시하시길


<!--
 참고한 사이트
-->
## References
- 