### PR TITLE
feat: 클라이언트 이미지 삭제 작업 스케줄링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	// 스프링 배치
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientImageRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientImageRepository.java
@@ -1,0 +1,16 @@
+package com.map.gaja.client.infrastructure.repository;
+
+import com.map.gaja.client.domain.model.ClientImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ClientImageRepository extends JpaRepository<ClientImage, Long> {
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("DELETE FROM ClientImage ci " +
+            "WHERE ci.id IN :ids")
+    void deleteClientImagesInIds(@Param(value = "ids") List<Long> ids);
+}

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -1,6 +1,7 @@
 package com.map.gaja.client.infrastructure.repository;
 
 import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.client.domain.model.ClientImage;
 import com.map.gaja.client.infrastructure.repository.querydsl.sql.NativeSqlCreator;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.request.subdto.AddressDto;
@@ -13,6 +14,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 
@@ -75,6 +77,7 @@ public class ClientQueryRepository {
 
     /**
      * 그룹을 패치 조인 해서 Client 검색
+     *
      * @param clientId
      * @return
      */
@@ -91,6 +94,7 @@ public class ClientQueryRepository {
 
     /**
      * Group 내에 있는 Client 조회
+     *
      * @param groupId
      * @return
      */
@@ -140,6 +144,7 @@ public class ClientQueryRepository {
 
     /**
      * 해당 그룹이 클라이언트를 가지고 있는지 확인
+     *
      * @param groupId
      * @param clientId
      * @return 가지고 있다면 true
@@ -158,6 +163,7 @@ public class ClientQueryRepository {
 
     /**
      * 해당 그룹이 클라이언트를 가지고 있지 않은지 확인
+     *
      * @param groupId
      * @param clientId
      * @return 가지고 있지 않다면 true
@@ -168,8 +174,9 @@ public class ClientQueryRepository {
 
     /**
      * loginEmail User가 가지고 있는 "삭제되지 않은 그룹"의 Client 전체 검색.
+     *
      * @param loginEmail 로그인한 이메일
-     * @param nameCond 이름 검색 조건
+     * @param nameCond   이름 검색 조건
      * @return
      */
     public List<ClientOverviewResponse> findActiveClientByEmail(String loginEmail, @Nullable String nameCond) {
@@ -215,7 +222,18 @@ public class ClientQueryRepository {
     }
 
     /**
-     *
+     * 삭제할 Client 이미지 경로 페이징 조회
+     */
+    public List<ClientImage> findImagePathsToDelete(long page, long size) {
+        return query
+                .selectFrom(clientImage)
+                .where(clientImage.isDeleted.isTrue())
+                .offset(page)
+                .limit(size + 1)
+                .fetch();
+    }
+
+    /**
      * groupId 내에 있는 Client들 중에 clientIds와 매칭되는 Client의 개수를 반환
      */
     public long findMatchingClientCountInGroup(long groupId, List<Long> clientIds) {

--- a/src/main/java/com/map/gaja/global/schedule/ImageDeletionTask.java
+++ b/src/main/java/com/map/gaja/global/schedule/ImageDeletionTask.java
@@ -1,0 +1,59 @@
+package com.map.gaja.global.schedule;
+
+import com.map.gaja.client.domain.exception.S3NotWorkingException;
+import com.map.gaja.client.domain.model.ClientImage;
+import com.map.gaja.client.infrastructure.repository.ClientImageRepository;
+import com.map.gaja.client.infrastructure.repository.ClientQueryRepository;
+import com.map.gaja.client.infrastructure.s3.S3FileService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ImageDeletionTask {
+    private static final long LIMIT_SIZE = 1000L;
+    private final S3FileService s3FileService;
+    private final ClientQueryRepository clientQueryRepository;
+    private final ClientImageRepository clientImageRepository;
+
+    /**
+     * DB에 삭제할 ClientImage가 존재하지 않을 때까지 LIMIT_SIZE만큼 ClientImage를 조회하고 s3에 해당 경로 이미지 삭제
+     * */
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul") // 초 분 시 => 한국 시간 매일 새벽 3시에 작업 수행
+    @Transactional
+    public void execute() {
+        long startTime = System.nanoTime();
+
+        //삭제할 데이터를 한번에 조회하는 것이 아니라 LIMIT_SIZE만큼 조회
+        while (true) {
+            List<ClientImage> clientImages = clientQueryRepository.findImagePathsToDelete(0L, LIMIT_SIZE);
+            List<Long> deleteIds = new ArrayList<>(); //삭제 할 id 저장
+
+            for (ClientImage clientImage : clientImages) {
+                try {
+                    s3FileService.removeFile(clientImage.getSavedPath());
+                } catch (S3NotWorkingException e) {
+                    clientImageRepository.deleteClientImagesInIds(deleteIds); // s3예외가 발생했지만 s3에서 삭제된 이미지가 있을 수도 있으므로 테이블에서도 레코드 삭제
+                    return;
+                }
+                deleteIds.add(clientImage.getId());
+            }
+
+            clientImageRepository.deleteClientImagesInIds(deleteIds);
+            if (clientImages.size() <= LIMIT_SIZE) { // 다음 데이터가 존재하는지 체크
+                break;
+            }
+        }
+
+        long executionTime = (System.nanoTime() - startTime) / 1000000;
+        log.info("Time: {} ms", executionTime);
+    }
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #237 

<!--
 전달할 내용
-->
## comment
- 클라이언트 벌크 삭제에 관련해서만 구현했는데 그룹과 회원탈퇴할 때 관련된 삭제 작업은 좀 더 고민해보고 작업하겠음 ( 남은 작업은 다른 브랜치 파서 하겠음)
- 스프링 배치가 아닌 스프링에서 기본적으로 제공하고 있는 @Schedule 를 사용해서 구현함.
- 스프링 배치는 삽질좀 했는데 기술적 어려움이 좀 있어서 @Schedule로 운영해보고 비효율적이라고 판단되면 스프링 배치를 도입하는 것이 좋아보임
- 그리고 log를 클래스별로 분리해서 다른 log파일에 기록하고 싶은데 이것도 알아보겠음

<!--
 참고한 사이트
-->
## References
- 