### PR TITLE
Feat/#245 모니터링 기본 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	// 모니터링 설정
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus' // 프로메테우스 마이크로 미터 구현체 추가
 
 	// bulk 쿼리를 위한 jdbc
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.11'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" // querydsl 설정
+	id "com.gorylenko.gradle-git-properties" version "2.4.1" // git 모니터링을 위한 플러그인 추가
 }
 
 group = 'com.map'
@@ -33,6 +34,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
+	// 모니터링 설정
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// bulk 쿼리를 위한 jdbc
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/src/main/java/com/map/gaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.map.gaja.global.config;
 import com.map.gaja.oauth2.application.Oauth2UserService;
 import com.map.gaja.oauth2.handler.Oauth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,12 +17,18 @@ public class SecurityConfig {
     private final Oauth2UserService oauth2UserService;
     private final Oauth2SuccessHandler oauth2SuccessHandler;
 
+    @Value("${management.endpoints.web.base-path}")
+    private String monitoringEndPoint;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        String monitoringPath = monitoringEndPoint+"/**";
+
         http
                 .httpBasic().disable()
                 .authorizeHttpRequests(request -> request
                         .antMatchers("/api/user/login",
+                                monitoringPath,
                                 "/", "/login", "/css/**", "/js/**", "/image/**", "/file/**" // 웹 페이지 설정
                         ).permitAll()
                         .anyRequest().authenticated())


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #245 

<!--
 전달할 내용
-->
## comment
- 기본 제공 모니터링 메트릭(CPU 사용량, 메모리 사용량, 커넥션 풀 등등)을 제외한
비즈니스 로직 관련 메트릭(ex- 가입자 수 등등)도 추가하려 했는데 
이건 나중에 필요해보이는 걸 따로 추려서 추가하는게 좋을 것 같아서 추가 안했다

<!--
 참고한 사이트
-->
## References
- 모니터링 환경 구성하면서 정리한 내용
https://velog.io/@sdsd0908/%EB%B9%A0%EB%A5%B4%EA%B2%8C-%EC%8A%A4%ED%94%84%EB%A7%81-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81-%ED%99%98%EA%B2%BD-%EA%B5%AC%EC%84%B1