### PR TITLE
feat: 스케줄링 작업 로그 파일 분리

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration status="info">
+
+    <!-- 날짜 / 스레드명 / 로깅레벨 / 로그 최대 글자수(36) / 메소드명:줄 / 로그메시지 -->
+    <property name="LOG_PATTERN" value = "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%method:%line - %msg%n"></property>
+
+    <!-- appender는 로그를 어떤 방식으로 넣을 것인지 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender"> <!-- 콘솔에 로그 출력 -->
+        <!-- 어떤 패턴으로 인코딩해서 출력할 것인지 -->
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+
+    <!-- 클래스 별 로그 파일 분리 -->
+    <appender name="ImageDeletionTask" class="ch.qos.logback.core.FileAppender"> <!-- 파일에 로그 출력 -->
+        <file>/logs/ImageDeletionTask.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+
+    <!-- 분리된 로그 파일 로그 설정 -->
+    <logger name="com.map.gaja.global.schedule.ImageDeletionTask" level="DEBUG" additivity="false">
+        <appender-ref ref="ImageDeletionTask" />
+    </logger>
+
+
+    <!-- 글로벌 로거라 모든 클래스에 대한 로그들이 콘솔에 출력. -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #246 

<!--
 전달할 내용
-->
## comment
- 클래스별로 로그 파일 분리함 여기서는 작업 스케줄링 클래스만 다른 로그 파일에 기록하도록 함
- 아래 문서에서 찾아보니깐 많은 설정을 할 수 있는데 
  로그 파일이 지정한 용량 수준 이상을 넘어가면 그 파일을 압축하고 새로운 파일에 로그를 다시 출력해주거나 
지정한 시간이 지난 로그 파일을 자동으로 삭제해주는 등 다양한 설정이 가능함 
 이런 것은 운영하기 전에 설정하면 될듯

<!--
 참고한 사이트
-->
## References
- https://www.baeldung.com/logback
- https://breakcoding.tistory.com/400