### PR TITLE
Fix/#248 /clients/bulk 저장 최적화

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientService.java
@@ -171,19 +171,17 @@ public class ClientService {
         return existingClient.getGroup().getId() != updateRequest.getGroupId();
     }
 
-    public List<Long> saveSimpleClientList(SimpleClientBulkRequest bulkRequest) {
+    public void saveSimpleClientList(SimpleClientBulkRequest bulkRequest) {
         Group group = groupQueryRepository.findGroupWithUser(bulkRequest.getGroupId())
                 .orElseThrow(() -> new GroupNotFoundException());
 
-        List<Long> savedIdList = new ArrayList<>();
+        List<Client> savedClient = new ArrayList<>();
         bulkRequest.getClients().forEach((clientRequest) -> {
-            Client client = dtoToEntity(clientRequest, group);
-            clientRepository.save(client);
-            savedIdList.add(client.getId());
+            savedClient.add(dtoToEntity(clientRequest, group));
         });
-        increasingClientService.increase(group, group.getUser().getAuthority(), savedIdList.size());
 
-        return savedIdList;
+        clientBulkRepository.saveClientWithGroup(group, savedClient);
+        increasingClientService.increase(group, group.getUser().getAuthority(), savedClient.size());
     }
 
     /**

--- a/src/main/java/com/map/gaja/client/apllication/ClientService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientService.java
@@ -180,8 +180,8 @@ public class ClientService {
             savedClient.add(dtoToEntity(clientRequest, group));
         });
 
-        clientBulkRepository.saveClientWithGroup(group, savedClient);
         increasingClientService.increase(group, group.getUser().getAuthority(), savedClient.size());
+        clientBulkRepository.saveClientWithGroup(group, savedClient);
     }
 
     /**

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientBulkRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientBulkRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -13,6 +14,7 @@ import java.sql.Types;
 import java.util.List;
 
 @Repository
+@Transactional
 @RequiredArgsConstructor
 public class ClientBulkRepository {
     private final JdbcTemplate template;

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -131,14 +131,14 @@ public class ClientController implements ClientCommandApiSpecification {
     }
 
     @PostMapping("/clients/bulk")
-    public ResponseEntity<List<Long>> addSimpleBulkClient(
+    public ResponseEntity<Void> addSimpleBulkClient(
             @AuthenticationPrincipal(expression = "name") String loginEmail,
             @Valid @RequestBody SimpleClientBulkRequest clientBulkRequest
     ) {
         // 단순한 Client 정보 등록
         groupAccessVerifyService.verifyGroupAccess(clientBulkRequest.getGroupId(), loginEmail);
-        List<Long> body = clientService.saveSimpleClientList(clientBulkRequest);
-        return new ResponseEntity<>(body, HttpStatus.CREATED);
+        clientService.saveSimpleClientList(clientBulkRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @PostMapping("/clients")

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
@@ -104,7 +104,7 @@ public interface ClientCommandApiSpecification {
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 그룹이 없거나, 그룹에 요청 고객이 없음 <br> 또는 그룹 내에 사용자 수보다 많은 사용자를 등록할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             })
     @PostMapping("/clients/bulk")
-    public ResponseEntity<List<Long>> addSimpleBulkClient(
+    public ResponseEntity<Void> addSimpleBulkClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @Valid @RequestBody SimpleClientBulkRequest clientBulkRequest
     );

--- a/src/main/java/com/map/gaja/group/domain/service/IncreasingClientService.java
+++ b/src/main/java/com/map/gaja/group/domain/service/IncreasingClientService.java
@@ -14,7 +14,7 @@ public class IncreasingClientService {
             return;
         }
 
-        throw new ClientLimitExceededException(authority.name(), group.getClientCount());
+        throw new ClientLimitExceededException(authority.name(), authority.getClientLimitCount());
     }
 
     private boolean isCreateClient(int clientLimitCount, int currentClientCount, int increaseInClient) {

--- a/src/test/java/com/map/gaja/TestEntityCreator.java
+++ b/src/test/java/com/map/gaja/TestEntityCreator.java
@@ -1,0 +1,48 @@
+package com.map.gaja;
+
+import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.client.domain.model.ClientAddress;
+import com.map.gaja.client.domain.model.ClientLocation;
+import com.map.gaja.group.domain.model.Group;
+import com.map.gaja.user.domain.model.User;
+
+public class TestEntityCreator {
+    public static Client createClient(int sigIdx, Group group) {
+        String sig = sigIdx+""+sigIdx;
+        double pointSig = 0.003;
+
+        String name = "사용자 " + sig;
+        String phoneNumber = "010-1111-" + sig;
+        ClientAddress address = new ClientAddress("address " + sig, "detail " + sig);
+        ClientLocation location = new ClientLocation(35d + pointSig * sigIdx, 125.0d + pointSig * sigIdx);
+        return new Client(name, phoneNumber, address, location, group);
+    }
+
+    public static Group createGroup(User user, String groupName) {
+        Group createdGroup = Group.builder()
+                .name(groupName)
+                .user(user)
+                .clientCount(0)
+                .isDeleted(false)
+                .build();
+        return createdGroup;
+    }
+
+    public static User createUser(String userEmail) {
+        return new User(userEmail);
+    }
+
+    public static Group createGroupWithUser(String userEmail, String groupName) {
+        User user = createUser(userEmail);
+        Group group = createGroup(user, groupName);
+        return group;
+    }
+
+    public static Group createGroupWithUser() {
+        String userEmail = "test@example.com";
+        String groupName = "Test Group";
+        User user = createUser(userEmail);
+        Group group = createGroup(user, groupName);
+        return group;
+    }
+}

--- a/src/test/java/com/map/gaja/client/apllication/ClientBulkInsertTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientBulkInsertTest.java
@@ -1,0 +1,105 @@
+package com.map.gaja.client.apllication;
+
+import com.map.gaja.TestEntityCreator;
+import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.client.infrastructure.repository.ClientBulkRepository;
+import com.map.gaja.client.infrastructure.repository.ClientRepository;
+import com.map.gaja.group.domain.model.Group;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 각각의 성능을 보기 위한 테스트 코드
+ * 성능 비율
+ * JDBC 1
+ * saveAll 1.573
+ * save 2.637
+ */
+//@SpringBootTest
+public class ClientBulkInsertTest {
+    private final int loop = 10;
+    @Autowired
+    ClientRepository clientRepository;
+    @Autowired
+    ClientBulkRepository clientBulkRepository;
+
+    @Autowired
+    EntityManager em;
+
+    private Group group;
+    long start, end, runningTimeNano;
+
+    @BeforeEach
+    void beforeEach() {
+        group = TestEntityCreator.createGroupWithUser();
+        em.persist(group.getUser());
+        em.persist(group);
+        em.flush();
+    }
+
+//    @Test
+    @Transactional
+    void bulkInsertWithJpaSaveEachTest() {
+        start = System.nanoTime();
+
+        /*========================================*/
+        for (int i = 0; i < loop; i++) {
+            Client client = TestEntityCreator.createClient(i, group);
+            clientRepository.save(client);
+        }
+        /*========================================*/
+
+        end = System.nanoTime();
+        runningTimeNano = end - start;
+        double runningTimeMillis = runningTimeNano / 1_000_000.0;
+        System.out.println("동작 시간: " + runningTimeMillis);
+    }
+
+//    @Test
+    @Transactional
+    void bulkInsertWithJpaSaveAllTest() {
+        start = System.nanoTime();
+
+        /*========================================*/
+        List<Client> list = new ArrayList<>();
+        for (int i = 0; i < loop; i++) {
+            Client client = TestEntityCreator.createClient(i, group);
+            list.add(client);
+        }
+        clientRepository.saveAll(list);
+        /*========================================*/
+
+        end = System.nanoTime();
+        runningTimeNano = end - start;
+        double runningTimeMillis = runningTimeNano / 1_000_000.0;
+        System.out.println("동작 시간: " + runningTimeMillis);
+    }
+
+//    @Test
+    @Transactional
+    void bulkInsertWithJDBCTest() {
+        start = System.nanoTime();
+
+        /*========================================*/
+        List<Client> list = new ArrayList<>();
+        for (int i = 0; i < loop; i++) {
+            Client client = TestEntityCreator.createClient(i, group);
+            list.add(client);
+        }
+        clientBulkRepository.saveClientWithGroup(group, list);
+        /*========================================*/
+
+        end = System.nanoTime();
+        runningTimeNano = end - start;
+        double runningTimeMillis = runningTimeNano / 1_000_000.0;
+        System.out.println("동작 시간: " + runningTimeMillis);
+    }
+
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #248 

<!--
 전달할 내용
-->
## comment
- POST: /bulk/clinet를 할 때 JDBC Template을 사용해서 직접 insert하도록 수정함.
- `IncreasingClientService.increase`를 사용하면서 권한별로 가능한 ClientCount를 넘어섰을 때
발생하는 예외에 현재 Group의 ClientCount가 나오는 오류 수정함
= "회원님의 등급은 %s로 최대 %d명의 고객만 생성 가능합니다." 여기서 `%d`에 권한의 ClientCount가 들어가도록 수정함.

- `save()`, `saveAll()`, `JDBC Template`은 모두 성능이 다르게 나옴
```
 트렌잭션을 전파받았을 때 1만 건의 데이터 insert
JDBC Template batchUpdate의 수행시간: 1618.374ms
saveAll의 수행시간: 2546.2081ms
save의 수행시간: 4267.0589ms

 성능 비율
batchUpdate : saveAll : save = 1 : 1.573 : 2.637
```

이 글은 테스트하면서 정리한 글
https://velog.io/@sdsd0908/Spring-JPA-save-vs-saveAll-%EA%B7%B8%EB%A6%AC%EA%B3%A0-JDBC-Template

<!--
 참고한 사이트
-->
## References
- 