### PR TITLE
Fix/#251 다수 고객 삭제 메소드 및 uri 변경

### DIFF
--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -57,7 +57,7 @@ public class ClientController implements ClientCommandApiSpecification {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    @PostMapping("/group/{groupId}/clients/bulk")
+    @PostMapping("/group/{groupId}/clients/bulk-delete")
     public ResponseEntity<Void> deleteBulkClient(
             @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -57,7 +57,7 @@ public class ClientController implements ClientCommandApiSpecification {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    @DeleteMapping("/group/{groupId}/clients/bulk")
+    @PostMapping("/group/{groupId}/clients/bulk")
     public ResponseEntity<Void> deleteBulkClient(
             @AuthenticationPrincipal(expression = "name") String loginEmail,
             @PathVariable Long groupId,

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
@@ -1,6 +1,5 @@
 package com.map.gaja.client.presentation.api.specification;
 
-import com.map.gaja.client.presentation.dto.access.ClientListAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.ClientIdsRequest;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
 
@@ -14,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindException;
@@ -22,7 +20,6 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.List;
 
 public interface ClientCommandApiSpecification {
 
@@ -50,7 +47,6 @@ public interface ClientCommandApiSpecification {
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorInfo.class)))),
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 그룹이 없거나 그룹에 요청 고객이 없음 <br> 또는 그룹 내에 사용자 수보다 많은 사용자를 제거할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             })
-    @DeleteMapping("/group/{groupId}/clients/bulk")
     public ResponseEntity<Void> deleteBulkClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @PathVariable Long groupId,
@@ -103,7 +99,6 @@ public interface ClientCommandApiSpecification {
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorInfo.class)))),
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 그룹이 없거나, 그룹에 요청 고객이 없음 <br> 또는 그룹 내에 사용자 수보다 많은 사용자를 등록할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             })
-    @PostMapping("/clients/bulk")
     public ResponseEntity<Void> addSimpleBulkClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @Valid @RequestBody SimpleClientBulkRequest clientBulkRequest


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #251 

<!--
 전달할 내용
-->
## comment
- 커밋 내용대로 DELETE에서 POST로 메소드를 변경하고 uri로 동작을 이해할 수 있도록 변경했다.
- 이렇게 다수의 고객 제거의 경우 body값이 허용되지 않기 때문에 애매하기 때문에 POST를 사용했다.

<!--
 참고한 사이트
-->
## References
- https://www.inflearn.com/questions/185085/%ED%95%9C%EB%B2%88%EC%97%90-%EC%97%AC%EB%9F%AC-%ED%9A%8C%EC%9B%90%EB%93%A4%EC%9D%84-%EC%83%9D%EC%84%B1-%EC%88%98%EC%A0%95-%EC%82%AD%EC%A0%9C-%ED%95%98%EB%A0%A4%EA%B3%A0-%ED%95%A0%EB%95%8C%EB%8A%94