### PR TITLE
Feat/#256 jacoco 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 src/main/resources/application.yml
 src/main/resources/application-*.yml
+
+### 로그 제거 ###
+ImageDeletionTask.log

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,18 @@ jacocoTestCoverageVerification {
 	}
 }
 
+task testCoverage(type: Test) {
+	group 'verification'
+	description 'Runs the unit tests with coverage'
+
+	dependsOn(':test',
+			':jacocoTestReport',
+			':jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
 group = 'com.map'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,76 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" // querydsl 설정
 	id "com.gorylenko.gradle-git-properties" version "2.4.1" // git 모니터링을 위한 플러그인 추가
+	id 'jacoco' // 테스트 커버리지 측정 설정
+}
+
+// 테스트 커버리지 측정 설정
+jacocoTestReport {
+	dependsOn test
+	reports {
+		html.enabled true
+		xml.enabled false
+		csv.enabled false
+	}
+
+	def Qdomains = []
+	for (qPattern in '**/QA'..'**/QZ') {
+		Qdomains.add(qPattern + '*')
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, excludes: [
+							"**/*Application*",
+							"**/*Config*",
+							"**/*Dto*",
+							"**/*Request*",
+							"**/*Response*",
+							"**/*Interceptor*",
+							"**/*Exception*"
+					] + Qdomains)
+				})
+		)
+	}
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+
+jacocoTestCoverageVerification {
+	def Qdomains = []
+	for (qPattern in '*.QA'..'*.QZ') {
+		Qdomains.add(qPattern + '*')
+	}
+
+	violationRules {
+		rule {
+			element = 'CLASS'
+			enabled = true
+
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.70
+			}
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.70
+			}
+
+			excludes = [
+					"**.*Application*",
+					"**.*Config*",
+					"**.*Dto*",
+					"**.*Request*",
+					"**.*Response*",
+					"**.*Interceptor*",
+					"**.*Exception*"
+			] + Qdomains
+		}
+	}
 }
 
 group = 'com.map'


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #256 

<!--
 전달할 내용
-->
## comment
- 지금 설정을 적용해보면 gradle에 다음과 같이 verification 항목이 추가된다.
![image](https://github.com/GaJaMap/backend/assets/88225377/2fc9ea48-34af-4e98-a16a-ff8de1317cac)
기존에는 `test` - `jacocoTestReposrt` - `jacocoTestCoverageVerification`을 순차적으로 실행해야 한다.
근데 해당 단계를 통합해서 순서대로 실행할 수 있도록 `testCoverage`를 만들어놨다.

- 해당 명령어를 실행하면 다음과 같이 `build/reports/jacoco/...`경로로 커버리지 확인 html 페이지가 나온다.
![image](https://github.com/GaJaMap/backend/assets/88225377/e61af6ec-33ef-41c5-a938-4a350bb427c9)
하단에 `index.html`을 크롬으로 열어서 확인하면 된다.
![image](https://github.com/GaJaMap/backend/assets/88225377/2683b585-befb-460f-904e-b3b5aa2257db)

그러면 다음 페이지를 확인할 수 있다.
![image](https://github.com/GaJaMap/backend/assets/88225377/31c66c05-392c-45b3-a4a6-c10803507c65)

- 지금은 분기문과 라인을 테스트 커비리지를 70%로 설정했다.
![image](https://github.com/GaJaMap/backend/assets/88225377/ca2764bc-cfb3-48ca-8a81-412e6c852f2c)
그래서 `testCoverage`를 실행하면 다음과 같이 `test` 단계에서 테스트는 모두 성공하지만 테스트 커버리지를 충족하지 못해서 실패로 나온다.
![image](https://github.com/GaJaMap/backend/assets/88225377/d85a00e3-dab5-44f2-bfaf-1757024339d6)


<!--
 참고한 사이트
-->
## References
jacoco 설정 관련
- https://junyharang.tistory.com/341
- https://techblog.woowahan.com/2661/
- https://learnote-dev.com/java/jacoco-%EC%A0%81%EC%9A%A9%ED%95%98%EC%97%AC-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BB%A4%EB%B2%84%EB%A6%AC%EC%A7%80-%EC%B2%B4%ED%81%AC%ED%95%98%EA%B8%B0/

jacoco 용어 관련: https://m.blog.naver.com/kmk1030/221267908910
task 통합 관련 : https://rkdals213.tistory.com/4