### PR TITLE
feat: 카카오 위경도 변환 api 비동기 통신

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,9 @@ dependencies {
 	// 스프링 배치
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 
+	//web-flux
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -15,11 +15,12 @@ import com.map.gaja.global.log.TimeCheckLog;
 import com.map.gaja.group.application.GroupAccessVerifyService;
 import com.map.gaja.group.application.GroupService;
 import com.map.gaja.location.LocationResolver;
+import com.map.gaja.location.exception.TooManyRequestException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,6 +31,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +40,7 @@ import java.util.List;
 @TimeCheckLog
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class WebClientController {
 
     private final ExcelParser excelParser;
@@ -79,10 +83,9 @@ public class WebClientController {
     }
 
 
-
     @PostMapping("/api/clients/file")
     @ResponseBody
-    public ResponseEntity<Integer> saveExcelFileData(
+    public Mono<Integer> saveExcelFileData(
             @AuthenticationPrincipal(expression = "name") String loginEmail,
             ClientExcelRequest excelRequest
     ) {
@@ -94,11 +97,19 @@ public class WebClientController {
 
         List<ClientExcelData> clientExcelData = excelParser.parseClientExcelFile(excelFile);
         validateClientData(clientExcelData);
-        locationResolver.convertCoordinate(clientExcelData);
 
-        clientService.saveClientExcelData(groupId, clientExcelData);
-        int successDataSize = clientExcelData.size();
-        return new ResponseEntity<>(successDataSize, HttpStatus.OK);
+        Mono<Void> mono = locationResolver.convertToCoordinatesAsync(clientExcelData);
+
+        return mono.doOnSuccess(s -> { //비동기 작업 모두 성공할 경우 후처리
+                    clientService.saveClientExcelData(groupId, clientExcelData);
+                })
+                .doOnError(err -> { //예외가 한번이라도 발생할 경우 후처리
+                    log.error("{}",loginEmail, err);
+                    if(err instanceof WebClientResponseException) { //429 예외처리
+                        throw new TooManyRequestException();
+                    }
+                })
+                .thenReturn(clientExcelData.size()); //저장 성공 수
     }
 
     private void validateClientData(List<ClientExcelData> clientExcelData) {

--- a/src/main/java/com/map/gaja/location/LocationResolver.java
+++ b/src/main/java/com/map/gaja/location/LocationResolver.java
@@ -14,8 +14,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Hooks;
 
+import javax.annotation.PostConstruct;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -29,6 +32,15 @@ public class LocationResolver {
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper mapper;
     private static final String KAKAO_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+    private WebClient webClient;
+
+    @PostConstruct
+    private void init() {
+        webClient = WebClient.builder()
+                .baseUrl(KAKAO_URL)
+                .defaultHeader("Authorization", "KakaoAK " + KAKAO_KEY)
+                .build();
+    }
 
     /**
      * 도로명 주소를 위도 경도로 변환

--- a/src/main/java/com/map/gaja/location/LocationResolver.java
+++ b/src/main/java/com/map/gaja/location/LocationResolver.java
@@ -40,6 +40,8 @@ public class LocationResolver {
                 .baseUrl(KAKAO_URL)
                 .defaultHeader("Authorization", "KakaoAK " + KAKAO_KEY)
                 .build();
+
+        Hooks.onErrorDropped(throwable -> {});
     }
 
     /**

--- a/src/main/java/com/map/gaja/location/LocationResolver.java
+++ b/src/main/java/com/map/gaja/location/LocationResolver.java
@@ -9,6 +9,7 @@ import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.location.exception.NotExcelUploadException;
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -21,6 +22,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LocationResolver {
     @Value("${kakao.key}")
     private String KAKAO_KEY;
@@ -36,7 +38,6 @@ public class LocationResolver {
     public void convertCoordinate(List<ClientExcelData> addresses) {
         try {
             HttpHeaders headers = createHeaders();
-
             for (ClientExcelData data : addresses) {
                 if (data.getAddress() == null) {
                     continue;
@@ -95,16 +96,20 @@ public class LocationResolver {
                 .toUri();
     }
 
-    private LocationDto parseLocation(String result) throws JsonProcessingException {
-        JsonNode jsonNode = mapper.readTree(result);
+    private LocationDto parseLocation(String result) {
+        try {
+            JsonNode jsonNode = mapper.readTree(result);
 
-        JsonNode documentsNode = jsonNode.get("documents");
-        if (documentsNode.isArray() && documentsNode.size() > 0) {
-            JsonNode documentNode = documentsNode.get(0);
-            double x = documentNode.get("x").asDouble();
-            double y = documentNode.get("y").asDouble();
+            JsonNode documentsNode = jsonNode.get("documents");
+            if (documentsNode.isArray() && documentsNode.size() > 0) {
+                JsonNode documentNode = documentsNode.get(0);
+                double x = documentNode.get("x").asDouble();
+                double y = documentNode.get("y").asDouble();
 
-            return new LocationDto(y, x);
+                return new LocationDto(y, x);
+            }
+        } catch(JsonProcessingException e){
+            throw new NotExcelUploadException(e);
         }
 
         return new LocationDto();

--- a/src/main/java/com/map/gaja/location/exception/NotExcelUploadException.java
+++ b/src/main/java/com/map/gaja/location/exception/NotExcelUploadException.java
@@ -7,4 +7,8 @@ public class NotExcelUploadException extends BusinessException {
     public NotExcelUploadException() {
         super(HttpStatus.BAD_REQUEST, "현재 엑셀 업로드 서비스를 사용할 수 없습니다.");
     }
+
+    public NotExcelUploadException(Throwable e) {
+        super(e, HttpStatus.BAD_REQUEST, "현재 엑셀 업로드 서비스를 사용할 수 없습니다.");
+    }
 }

--- a/src/main/java/com/map/gaja/location/exception/TooManyRequestException.java
+++ b/src/main/java/com/map/gaja/location/exception/TooManyRequestException.java
@@ -1,0 +1,11 @@
+package com.map.gaja.location.exception;
+
+import com.map.gaja.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class TooManyRequestException extends BusinessException {
+
+    public TooManyRequestException() {
+        super(HttpStatus.TOO_MANY_REQUESTS, "너무 많은 요청으로 잠시 후 이용 부탁드립니다.");
+    }
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #263

<!--
 전달할 내용
-->
## comment
- spring framework 5버전부터 mvc와 webflux간 서로 상호작용이 가능하다고 해서 webflux의존받고 비동기통신 처리함
- 병렬 처리와 논블로킹&비동기 으로 처리하기 때문에 속도가 빠른데 1000번 api요청 RestTemplate 동기로 할 경우 약 30초 걸리는거 WebClient 사용하면 3~4초만에 처리가능함.
문제는 카카오 geo api가 분당 10만건 정도의 요청만 처리하기 때문에 병렬 처리 수를 제한하지 않을 경우 429 Too Many Request가 터짐.
카카오랑 제휴를 맺으면 어느정도 제한이 풀리는 것 같은데 일단 무료니깐 병렬 처리를 2개로 제한했음.  2개로 해서 약 15초정도 걸림
- 기존 메소드는 남겨놨음

- webflux 기능을 다 쓴게 아니고 WebClient를 사용하기 위해서 webflux 의존 받고 사용한 거라서 완벽하게 잘 모르는데  동작 원리는 대충 이해하고 있어서 이해 안된다면 나중에 만나서 동작 원리라도 설명해드림

<!--
 참고한 사이트
-->
## References
- https://docs.spring.io/spring-framework/reference/web/webflux/new-framework.html
- https://happycloud-lee.tistory.com/220
- https://www.baeldung.com/spring-5-webclient
- https://sjh836.tistory.com/149