### PR TITLE
웹에서 엑셀 처리 시 카카오 API 호출 전 ClientCount 체크하도록 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientService.java
@@ -197,7 +197,7 @@ public class ClientService {
             savedClient.add(dtoToEntity(clientData, group));
         });
 
-        group.increaseClientCount(savedClient.size());
+        increasingClientService.increase(group, group.getUser().getAuthority(), savedClient.size());
         clientBulkRepository.saveClientWithGroup(group, savedClient);
     }
 

--- a/src/main/java/com/map/gaja/client/presentation/dto/subdto/GroupDetailDto.java
+++ b/src/main/java/com/map/gaja/client/presentation/dto/subdto/GroupDetailDto.java
@@ -1,0 +1,16 @@
+package com.map.gaja.client.presentation.dto.subdto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+public class GroupDetailDto extends GroupInfoDto {
+    @Schema(description = "그룹에 속한 고객수")
+    private int clientCount;
+
+    public GroupDetailDto(Long groupId, String groupName, int clientCount) {
+        super(groupId, groupName);
+        this.clientCount = clientCount;
+    }
+}

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -7,7 +7,7 @@ import com.map.gaja.client.infrastructure.file.excel.ClientExcelData;
 import com.map.gaja.client.infrastructure.file.excel.ExcelParser;
 import com.map.gaja.client.presentation.dto.request.ClientExcelRequest;
 import com.map.gaja.client.presentation.dto.response.InvalidExcelDataResponse;
-import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
+import com.map.gaja.client.presentation.dto.subdto.GroupDetailDto;
 
 import com.map.gaja.global.authentication.PrincipalDetails;
 import com.map.gaja.global.log.TimeCheckLog;
@@ -61,7 +61,7 @@ public class WebClientController {
 
         String email = authentication.getName(); //이메일
 
-        List<GroupInfoDto> activeGroupInfo = groupService.findActiveGroupInfo(email);
+        List<GroupDetailDto> activeGroupInfo = groupService.findActiveGroupInfo(email);
         model.addAttribute("groupList", activeGroupInfo);
 
         return "index";

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -1,10 +1,12 @@
 package com.map.gaja.client.presentation.web;
 
+import com.map.gaja.client.apllication.ClientAccessVerifyService;
 import com.map.gaja.client.apllication.ClientService;
 import com.map.gaja.client.domain.exception.InvalidClientRowDataException;
 import com.map.gaja.client.infrastructure.file.FileValidator;
 import com.map.gaja.client.infrastructure.file.excel.ClientExcelData;
 import com.map.gaja.client.infrastructure.file.excel.ExcelParser;
+import com.map.gaja.client.presentation.dto.access.ClientListAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.ClientExcelRequest;
 import com.map.gaja.client.presentation.dto.response.InvalidExcelDataResponse;
 import com.map.gaja.client.presentation.dto.subdto.GroupDetailDto;
@@ -93,10 +95,10 @@ public class WebClientController {
         MultipartFile excelFile = excelRequest.getExcelFile();
         FileValidator.verifyFile(excelFile);
 
-        groupAccessVerifyService.verifyGroupAccess(groupId, loginEmail);
-
         List<ClientExcelData> clientExcelData = excelParser.parseClientExcelFile(excelFile);
         validateClientData(clientExcelData);
+
+        groupAccessVerifyService.verifyClientInsertAccess(groupId, loginEmail, clientExcelData.size());
 
         Mono<Void> mono = locationResolver.convertToCoordinatesAsync(clientExcelData);
 

--- a/src/main/java/com/map/gaja/group/application/GroupAccessVerifyService.java
+++ b/src/main/java/com/map/gaja/group/application/GroupAccessVerifyService.java
@@ -1,8 +1,11 @@
 package com.map.gaja.group.application;
 
+import com.map.gaja.group.domain.exception.ClientLimitExceededException;
 import com.map.gaja.group.domain.exception.GroupNotFoundException;
 import com.map.gaja.group.domain.model.Group;
+import com.map.gaja.group.domain.service.IncreasingClientService;
 import com.map.gaja.group.infrastructure.GroupQueryRepository;
+import com.map.gaja.user.domain.model.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupAccessVerifyService {
     private final GroupQueryRepository groupQueryRepository;
+    private final IncreasingClientService increasingClientService;
 
     public void verifyGroupAccess(long groupId, String userEmail) {
         Group group = groupQueryRepository.findGroupWithUser(groupId)
@@ -19,6 +23,27 @@ public class GroupAccessVerifyService {
 
         if (isNotMatchingEmail(group, userEmail) || isDeleted(group)) {
             throw new GroupNotFoundException();
+        }
+
+        group.getUser().accessGroup(groupId);
+    }
+
+    /**
+     * Excel 파싱후 Insert 진행 중,
+     * 카카오 API 호출 전에 해당 함수를 호출해서 API 호출 수를 줄이기 위해 만들었다.
+     * verifyGroupAccess + 현재 insertCount의 수 만큼 Group에 넣을 수 있는지
+     */
+    public void verifyClientInsertAccess(long groupId, String userEmail, int insertCount) {
+        Group group = groupQueryRepository.findGroupWithUser(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+        Authority userAuth = group.getUser().getAuthority();
+
+        if (isNotMatchingEmail(group, userEmail) || isDeleted(group)) {
+            throw new GroupNotFoundException();
+        }
+
+        if (!increasingClientService.isCreateClient(userAuth.getClientLimitCount(), group.getClientCount(), insertCount)) {
+            throw new ClientLimitExceededException(userAuth.name(), userAuth.getClientLimitCount());
         }
 
         group.getUser().accessGroup(groupId);

--- a/src/main/java/com/map/gaja/group/application/GroupService.java
+++ b/src/main/java/com/map/gaja/group/application/GroupService.java
@@ -1,6 +1,6 @@
 package com.map.gaja.group.application;
 
-import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
+import com.map.gaja.client.presentation.dto.subdto.GroupDetailDto;
 import com.map.gaja.group.domain.exception.GroupNotFoundException;
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.group.infrastructure.GroupQueryRepository;
@@ -62,7 +62,7 @@ public class GroupService {
      * @return
      */
     @Transactional(readOnly = true)
-    public List<GroupInfoDto> findActiveGroupInfo(String email) {
+    public List<GroupDetailDto> findActiveGroupInfo(String email) {
         return groupQueryRepository.findActiveGroupInfo(email);
     }
 

--- a/src/main/java/com/map/gaja/group/domain/exception/ClientLimitExceededException.java
+++ b/src/main/java/com/map/gaja/group/domain/exception/ClientLimitExceededException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class ClientLimitExceededException extends BusinessException {
     public ClientLimitExceededException(String authority, Integer clientLimitCount) {
-        super(HttpStatus.FORBIDDEN, String.format("회원님의 등급은 %s로 최대 %d명의 고객만 생성 가능합니다.", authority, clientLimitCount));
+        super(HttpStatus.FORBIDDEN, String.format("회원님의 등급은 %s로 그룹 내에 최대 %d명의 고객만 생성 가능합니다.", authority, clientLimitCount));
     }
 }

--- a/src/main/java/com/map/gaja/group/domain/service/IncreasingClientService.java
+++ b/src/main/java/com/map/gaja/group/domain/service/IncreasingClientService.java
@@ -17,7 +17,7 @@ public class IncreasingClientService {
         throw new ClientLimitExceededException(authority.name(), authority.getClientLimitCount());
     }
 
-    private boolean isCreateClient(int clientLimitCount, int currentClientCount, int increaseInClient) {
+    public boolean isCreateClient(int clientLimitCount, int currentClientCount, int increaseInClient) {
         if (clientLimitCount >= (currentClientCount + increaseInClient)) {
             return true;
         }

--- a/src/main/java/com/map/gaja/group/infrastructure/GroupQueryRepository.java
+++ b/src/main/java/com/map/gaja/group/infrastructure/GroupQueryRepository.java
@@ -1,5 +1,6 @@
 package com.map.gaja.group.infrastructure;
 
+import com.map.gaja.client.presentation.dto.subdto.GroupDetailDto;
 import com.map.gaja.client.presentation.dto.subdto.GroupInfoDto;
 import com.map.gaja.group.domain.model.Group;
 import com.querydsl.core.types.Projections;
@@ -63,8 +64,8 @@ public class GroupQueryRepository {
      * @param userEmail 로그인한 Email
      * @return 가지고 있는 그룹의 ID List
      */
-    public List<GroupInfoDto> findActiveGroupInfo(String userEmail) {
-        return query.select(Projections.constructor(GroupInfoDto.class, group.id, group.name))
+    public List<GroupDetailDto> findActiveGroupInfo(String userEmail) {
+        return query.select(Projections.constructor(GroupDetailDto.class, group.id, group.name, group.clientCount))
                 .from(group)
                 .join(group.user, user).on(user.email.eq(userEmail))
                 .where(group.isDeleted.eq(Boolean.FALSE))

--- a/src/main/resources/templates/fragments/group-radio.html
+++ b/src/main/resources/templates/fragments/group-radio.html
@@ -25,7 +25,7 @@
       그룹을 클릭해서 선택해주세요.
     </div>
     <div style="cursor:pointer" class="list-group-item list-group-item-action" onclick="selectItem(this)" th:each="group: ${groupList}"  th:value="${group.groupId}">
-      <span th:text="${group.groupName}">그룹명</span>
+      <span th:text="|${group.groupName} (${group.clientCount})|">그룹명 (그룹 내 고객 수)</span>
     </div>
   </div>
   <input type="hidden" name="groupId" id="groupId">


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #271 

<!--
 전달할 내용
-->
## comment
- "카카오 API 호출을 줄이자"가 목표
카카오 API 호출 전에 엑셀의 데이터 사이즈를 확인해서 DB에 clientCount랑 비교해서 권한을 넘으면 예외 발생

- 추가적으로 그룹 리스트에 ClientCount도 보이도록 수정
![image](https://github.com/GaJaMap/backend/assets/88225377/59838749-374e-40de-a3cc-cc1dd320e255)


<!--
 참고한 사이트
-->
## References
- 