### PR TITLE
feat: 안드로이드 자동로그인에 대한 API 

### DIFF
--- a/src/main/java/com/map/gaja/group/application/GroupService.java
+++ b/src/main/java/com/map/gaja/group/application/GroupService.java
@@ -58,6 +58,7 @@ public class GroupService {
 
     /**
      * 삭제되지 않은 그룹 정보 반환 -> 엑셀 등록 시에 그룹 정보 출력을 위해 필요.
+     *
      * @param email 로그인 이메일
      * @return
      */
@@ -86,5 +87,27 @@ public class GroupService {
         Group group = groupRepository.findByIdAndUserId(groupId, user.getId())
                 .orElseThrow(GroupNotFoundException::new);
         group.updateName(request.getName());
+    }
+
+    /**
+     * 사용자가 최근에 참조한 그룹 조회
+     * 최근 참조 그룹 아이디가 NULL이면 전체 조회, NULL이 아니라면 특정 그룹 조회
+     */
+    public GroupInfo findGroup(String email) {
+        User user = findExistingUser(userRepository, email);
+
+        if (isWholeGroup(user.getReferenceGroupId())) {
+            return null;
+        }
+
+        GroupInfo groupInfo = groupRepository.findGroupInfoById(user.getReferenceGroupId());
+        return groupInfo;
+    }
+
+    private boolean isWholeGroup(Long referenceGroupId) {
+        if (referenceGroupId == null) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/map/gaja/group/infrastructure/GroupRepository.java
+++ b/src/main/java/com/map/gaja/group/infrastructure/GroupRepository.java
@@ -48,4 +48,10 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     @Modifying
     @Query(value = "DELETE FROM Group g WHERE g.isDeleted = true")
     int deleteMarkedGroups();
+
+    /**
+     * 사용자가 최근에 참조한 그룹 정보 조회
+     */
+    @Query("SELECT g.id as groupId, g.name as groupName, g.clientCount as clientCount FROM Group g WHERE g.id = :groupId AND g.isDeleted = false")
+    GroupInfo findGroupInfoById(@Param(value = "groupId") Long groupId);
 }

--- a/src/main/java/com/map/gaja/user/presentation/api/UserController.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/UserController.java
@@ -48,6 +48,7 @@ public class UserController implements UserApiSpecification {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Override
     @GetMapping("/auto-login")
     public ResponseEntity<AutoLoginResponse> autoLogin(@AuthenticationPrincipal(expression = "name") String email) {
         GroupInfo groupInfo = groupService.findGroup(email);

--- a/src/main/java/com/map/gaja/user/presentation/api/UserController.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/UserController.java
@@ -1,9 +1,14 @@
 package com.map.gaja.user.presentation.api;
 
+import com.map.gaja.client.apllication.ClientQueryService;
+import com.map.gaja.client.presentation.dto.response.ClientListResponse;
 import com.map.gaja.global.log.TimeCheckLog;
+import com.map.gaja.group.application.GroupService;
+import com.map.gaja.group.presentation.dto.response.GroupInfo;
 import com.map.gaja.user.application.UserService;
 import com.map.gaja.user.presentation.dto.request.LoginRequest;
 import com.map.gaja.user.presentation.api.specification.UserApiSpecification;
+import com.map.gaja.user.presentation.dto.response.AutoLoginResponse;
 import com.map.gaja.user.presentation.dto.response.LoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +24,8 @@ import javax.servlet.http.HttpSession;
 @RequiredArgsConstructor
 public class UserController implements UserApiSpecification {
     private final UserService userService;
+    private final ClientQueryService clientQueryService;
+    private final GroupService groupService;
 
     @Override
     @PostMapping("/login")
@@ -39,5 +46,27 @@ public class UserController implements UserApiSpecification {
         userService.withdrawal(email);
         session.invalidate();
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/auto-login")
+    public ResponseEntity<AutoLoginResponse> autoLogin(@AuthenticationPrincipal(expression = "name") String email) {
+        GroupInfo groupInfo = groupService.findGroup(email);
+
+        ClientListResponse clientListResponse;
+        if (isWholeGroup(groupInfo)) { //최근에 참조한 그룹이 전체일 경우
+            clientListResponse = clientQueryService.findAllClient(email, null);
+        } else { //최근에 참조한 그룹이 특정 그룹일 경우
+            clientListResponse = clientQueryService.findAllClientsInGroup(groupInfo.getGroupId(), null);
+        }
+
+        AutoLoginResponse response = new AutoLoginResponse(clientListResponse, groupInfo);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    private boolean isWholeGroup(GroupInfo groupInfo) {
+        if (groupInfo == null) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
@@ -3,6 +3,7 @@ package com.map.gaja.user.presentation.api.specification;
 import com.map.gaja.global.exception.ExceptionDto;
 import com.map.gaja.user.presentation.dto.request.LoginRequest;
 
+import com.map.gaja.user.presentation.dto.response.AutoLoginResponse;
 import com.map.gaja.user.presentation.dto.response.LoginResponse;
 import io.swagger.v3.oas.annotations.Operation;
 
@@ -48,5 +49,17 @@ public interface UserApiSpecification {
             }
     )
     ResponseEntity<Void> withdrawal(@Parameter(hidden = true) String email, HttpSession session);
+
+    @Operation(summary = "앱 자동로그인 처리(앱 실행할 때마다 요청)",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자가 최근에 참조한 그룹정보와, 그룹에 속한 고객들 응답"),
+                    @ApiResponse(responseCode = "403", description = "권한이 없음(세션이 만료되었거나 로그인처리가 안된 사용자)", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+            }
+    )
+    ResponseEntity<AutoLoginResponse> autoLogin(@Parameter(hidden = true) String email);
 
 }

--- a/src/main/java/com/map/gaja/user/presentation/dto/response/AutoLoginResponse.java
+++ b/src/main/java/com/map/gaja/user/presentation/dto/response/AutoLoginResponse.java
@@ -1,0 +1,17 @@
+package com.map.gaja.user.presentation.dto.response;
+
+import com.map.gaja.client.presentation.dto.response.ClientListResponse;
+import com.map.gaja.group.presentation.dto.response.GroupInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AutoLoginResponse {
+    @Schema(description = "고객 api 호출한 클래스와 동일")
+    private ClientListResponse clientListResponse;
+
+    @Schema(description = "최근에 참조한 그룹 정보")
+    private GroupInfo groupInfo;
+}

--- a/src/main/java/com/map/gaja/user/presentation/dto/response/AutoLoginResponse.java
+++ b/src/main/java/com/map/gaja/user/presentation/dto/response/AutoLoginResponse.java
@@ -12,6 +12,6 @@ public class AutoLoginResponse {
     @Schema(description = "고객 api 호출한 클래스와 동일")
     private ClientListResponse clientListResponse;
 
-    @Schema(description = "최근에 참조한 그룹 정보")
+    @Schema(description = "최근에 참조한 그룹 정보인데 NULL이면 전체이고, NULL이 아니면 특정 그룹에 대한 정보가 있으니 앱에서 NULL을 분기처리 해줘야함")
     private GroupInfo groupInfo;
 }

--- a/src/test/java/com/map/gaja/group/application/GroupServiceTest.java
+++ b/src/test/java/com/map/gaja/group/application/GroupServiceTest.java
@@ -5,6 +5,7 @@ import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.group.infrastructure.GroupRepository;
 import com.map.gaja.group.presentation.dto.request.GroupCreateRequest;
 import com.map.gaja.group.presentation.dto.request.GroupUpdateRequest;
+import com.map.gaja.group.presentation.dto.response.GroupInfo;
 import com.map.gaja.user.domain.exception.GroupLimitExceededException;
 import com.map.gaja.user.domain.model.Authority;
 import com.map.gaja.user.domain.model.User;
@@ -162,7 +163,7 @@ class GroupServiceTest {
     }
 
     @Test
-    @DisplayName("전체 그룹 조회")
+    @DisplayName("사용자가 최근에 참조한 그룹이 전체인 경우")
     void findWholeGroup() {
         String email = "test@gmail.com";
         User user = new User(email);
@@ -172,4 +173,18 @@ class GroupServiceTest {
         assertEquals(null, groupService.findGroup(email));
     }
 
+    @Test
+    @DisplayName("사용자가 최근에 참조한 그룹이 특정 그룹일 경우")
+    void findReferenceGroup() {
+        String email = "test@gmail.com";
+        User user = new User(email);
+        user.accessGroup(1L);
+        GroupInfo mockGroupInfo = mock(GroupInfo.class);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(groupRepository.findGroupInfoById(any())).thenReturn(mockGroupInfo);
+        groupService.findGroup(email);
+
+        verify(groupRepository, times(1)).findGroupInfoById(any());
+    }
 }

--- a/src/test/java/com/map/gaja/group/application/GroupServiceTest.java
+++ b/src/test/java/com/map/gaja/group/application/GroupServiceTest.java
@@ -21,7 +21,6 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -113,7 +112,7 @@ class GroupServiceTest {
         assertThatThrownBy(() -> {
             groupService.delete(email, 1L);
         })
-        .isInstanceOf(GroupNotFoundException.class);
+                .isInstanceOf(GroupNotFoundException.class);
 
     }
 
@@ -160,6 +159,17 @@ class GroupServiceTest {
 
         groupService.updateName(email, 1L, request);
         assertEquals(request.getName(), group.getName());
+    }
+
+    @Test
+    @DisplayName("전체 그룹 조회")
+    void findWholeGroup() {
+        String email = "test@gmail.com";
+        User user = new User(email);
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        assertEquals(null, groupService.findGroup(email));
     }
 
 }

--- a/src/test/java/com/map/gaja/group/infrastructure/GroupRepositoryTest.java
+++ b/src/test/java/com/map/gaja/group/infrastructure/GroupRepositoryTest.java
@@ -187,4 +187,18 @@ class GroupRepositoryTest {
         assertEquals("name", groupInfo.getGroupName());
         assertEquals(0, groupInfo.getClientCount());
     }
+
+    @Test
+    @DisplayName("사용자가 최근에 참조한 그룹 정보 조회 null 테스트")
+    void findGroupInfoNull() {
+        //given
+        User user = new User("test");
+        userRepository.save(user);
+
+        //when
+        GroupInfo groupInfo = groupRepository.findGroupInfoById(0L);
+
+        //then
+        assertEquals(null, groupInfo);
+    }
 }

--- a/src/test/java/com/map/gaja/group/infrastructure/GroupRepositoryTest.java
+++ b/src/test/java/com/map/gaja/group/infrastructure/GroupRepositoryTest.java
@@ -167,4 +167,24 @@ class GroupRepositoryTest {
         //then
         assertEquals(5, result);
     }
+
+    @Test
+    @DisplayName("사용자가 최근에 참조한 그룹 정보 조회")
+    void findGroupInfo() {
+        //given
+        User user = new User("test");
+        userRepository.save(user);
+
+        Group group = new Group("name", user);
+        groupRepository.save(group);
+        user.accessGroup(group.getId());
+
+        //when
+        GroupInfo groupInfo = groupRepository.findGroupInfoById(group.getId());
+
+        //then
+        assertEquals(group.getId(), groupInfo.getGroupId());
+        assertEquals("name", groupInfo.getGroupName());
+        assertEquals(0, groupInfo.getClientCount());
+    }
 }

--- a/src/test/java/com/map/gaja/user/presentation/api/UserControllerTest.java
+++ b/src/test/java/com/map/gaja/user/presentation/api/UserControllerTest.java
@@ -59,4 +59,40 @@ class UserControllerTest {
         verify(clientQueryService, times(1)).findAllClient(email, null);
     }
 
+    @Test
+    @DisplayName("사용자가 최근에 참조한 특정 그룹 조회")
+    void findGroup() throws Exception {
+        String email = "test@gmail.com";
+        GroupInfo groupInfo = new GroupInfo() {
+            @Override
+            public Long getGroupId() {
+                return null;
+            }
+
+            @Override
+            public String getGroupName() {
+                return null;
+            }
+
+            @Override
+            public Integer getClientCount() {
+                return null;
+            }
+        };
+        when(groupService.findGroup(email)).thenReturn(groupInfo);
+
+        ClientListResponse clientListResponse = new ClientListResponse();
+        when(clientQueryService.findAllClientsInGroup(groupInfo.getGroupId(), null)).thenReturn(clientListResponse);
+
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get("/api/user/auto-login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails("test@gmail.com", "FREE")));
+
+        mvc.perform(builder)
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        verify(clientQueryService, times(1)).findAllClientsInGroup(groupInfo.getGroupId(), null);
+    }
+
 }

--- a/src/test/java/com/map/gaja/user/presentation/api/UserControllerTest.java
+++ b/src/test/java/com/map/gaja/user/presentation/api/UserControllerTest.java
@@ -1,0 +1,62 @@
+package com.map.gaja.user.presentation.api;
+
+import com.map.gaja.client.apllication.ClientQueryService;
+import com.map.gaja.client.presentation.dto.response.ClientListResponse;
+import com.map.gaja.global.authentication.PrincipalDetails;
+import com.map.gaja.group.application.GroupService;
+import com.map.gaja.group.presentation.dto.response.GroupInfo;
+import com.map.gaja.user.application.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class UserControllerTest {
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    GroupService groupService;
+
+    @MockBean
+    ClientQueryService clientQueryService;
+
+    @Test
+    @DisplayName("사용자가 최근에 참조한 전체 그룹 조회")
+    void findWholeGroup() throws Exception {
+        String email = "test@gmail.com";
+        GroupInfo groupInfo = null;
+        when(groupService.findGroup(email)).thenReturn(groupInfo);
+
+        ClientListResponse clientListResponse = new ClientListResponse();
+        when(clientQueryService.findAllClient(email, null)).thenReturn(clientListResponse);
+
+        MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.get("/api/user/auto-login")
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails("test@gmail.com", "FREE")));
+
+        mvc.perform(builder)
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(clientQueryService, times(1)).findAllClient(email, null);
+    }
+
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #273 

<!--
 전달할 내용
-->
## comment
- 자동로그인 처리를 앱단에서 처리하려고 했는데 좀 힘들어 할 것 같아서 백엔드에서 api만들어주면 쉬울 거라고 판단돼서 만들었음
- 앱을 실행할 때마다 해당 api를 요청하는데 최근에 참조한 그룹정보와 그 그룹에 속한 고객들을 응답해줌
고객에 대한 조회는 현우 너가 만들어 놓은 거 썼는데 파라미터에 wordCond는 NULL로 줬는데 맞음?

<!--
 참고한 사이트
-->
## References
- 