### PR TITLE
feat: 로그인 성공시 응답 필드값 수정

### DIFF
--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 import static com.map.gaja.user.application.UserServiceHelper.findExistingUser;
 
@@ -41,7 +42,10 @@ public class UserService {
 
         authenticationHandler.saveContext(email, user.getAuthority().toString()); //SecurityContextHolder에 인증 객체 저장
 
-        return new LoginResponse(user.getReferenceGroupId(), user.getAuthority().name());
+        return new LoginResponse(email,
+                user.getAuthority().name(),
+                user.getLastLoginDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        );
     }
 
     public void withdrawal(String email) {

--- a/src/main/java/com/map/gaja/user/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/map/gaja/user/presentation/dto/response/LoginResponse.java
@@ -7,9 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class LoginResponse {
-    @Schema(description = "최근에 참조한 그룹아이디 => null이면 전체 고객 검색 api호출 / null이 아니면 특정 그룹 고객 전부 조회 api호출")
-    private Long groupId;
+    @Schema(description = "이메일")
+    private String email;
 
     @Schema(description = "사용자 권한 등급 FREE(그룹1개, 각 그룹당 고객 200명), VIP(그룹500개, 각 그룹당 고객 1000명)")
     private String authority;
+
+    @Schema(description = "생성일")
+    private String createdDate;
+
+
+
 }


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #276 

<!--
 전달할 내용
-->
## comment
- 앱 로컬DB에 저장해놓고 설정페이지에서 사용
- 로그인 성공 응답 값 이메일, 등급, 생성일로 수정
- 자동로그인 api를 만들었기 때문에 최근 참조 그룹아이디 필드는 제거

<!--
 참고한 사이트
-->
## References
- 