### PR TITLE
fix: 회원 탈퇴한 유저가 로그인할 경우 예외처리

### DIFF
--- a/src/main/java/com/map/gaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.map.gaja.global.config;
 
 import com.map.gaja.oauth2.application.Oauth2UserService;
+import com.map.gaja.oauth2.handler.Oauth2FailureHandler;
 import com.map.gaja.oauth2.handler.Oauth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.Http403ForbiddenEntryPoin
 public class SecurityConfig {
     private final Oauth2UserService oauth2UserService;
     private final Oauth2SuccessHandler oauth2SuccessHandler;
+    private final Oauth2FailureHandler oauth2FailureHandler;
 
     @Value("${management.endpoints.web.base-path}")
     private String monitoringEndPoint;
@@ -38,6 +40,7 @@ public class SecurityConfig {
                     .userInfoEndpoint().userService(oauth2UserService) //oauth2 로그인 후 처리 로직
                 .and()
                 .successHandler(oauth2SuccessHandler) //웹에서 oauth2 로그인 성공할 경우
+                .failureHandler(oauth2FailureHandler) //웹에서 oauth2 로그인 실패할 경우(회원탈퇴 유저가 로그인하면 예외)
                 .and()
                 .exceptionHandling()
                     .authenticationEntryPoint(new Http403ForbiddenEntryPoint()); //인증되지 없을 경우 로그인 창으로 이동하는데 앱에서는 403으로 응답해주기 위해서 403으로 통일함

--- a/src/main/java/com/map/gaja/group/application/GroupService.java
+++ b/src/main/java/com/map/gaja/group/application/GroupService.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.map.gaja.user.application.UserServiceHelper.findExistingUser;
+import static com.map.gaja.user.application.UserServiceHelper.findByEmailAndActive;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +32,7 @@ public class GroupService {
 
     @Transactional
     public Long create(String email, GroupCreateRequest request) {
-        User user = findExistingUser(userRepository, email);
+        User user = findByEmailAndActive(userRepository, email);
 
         user.checkCreateGroupPermission();
 
@@ -49,7 +49,7 @@ public class GroupService {
 
     @Transactional(readOnly = true)
     public GroupResponse findGroups(String email, Pageable pageable) {
-        User user = findExistingUser(userRepository, email);
+        User user = findByEmailAndActive(userRepository, email);
 
         Slice<GroupInfo> groupInfos = groupRepository.findGroupByUserId(user.getId(), pageable);
 
@@ -69,7 +69,7 @@ public class GroupService {
 
     @Transactional
     public void delete(String email, Long groupId) {
-        User user = findExistingUser(userRepository, email);
+        User user = findByEmailAndActive(userRepository, email);
 
         int deletedGroupCount = groupRepository.deleteByIdAndUserId(groupId, user.getId());
 
@@ -82,7 +82,7 @@ public class GroupService {
 
     @Transactional
     public void updateName(String email, Long groupId, GroupUpdateRequest request) {
-        User user = findExistingUser(userRepository, email);
+        User user = findByEmailAndActive(userRepository, email);
 
         Group group = groupRepository.findByIdAndUserId(groupId, user.getId())
                 .orElseThrow(GroupNotFoundException::new);

--- a/src/main/java/com/map/gaja/oauth2/application/Oauth2UserService.java
+++ b/src/main/java/com/map/gaja/oauth2/application/Oauth2UserService.java
@@ -2,6 +2,7 @@ package com.map.gaja.oauth2.application;
 
 import com.map.gaja.global.authentication.PrincipalDetails;
 import com.map.gaja.global.authentication.SessionHandler;
+import com.map.gaja.user.application.UserServiceHelper;
 import com.map.gaja.user.domain.model.User;
 import com.map.gaja.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +29,7 @@ public class Oauth2UserService implements OAuth2UserService<OAuth2UserRequest, O
 
         String email = (String) ((Map) attributes.get("kakao_account")).get("email");
 
-        User user = userRepository.findByEmail(email)
-                .orElse(new User(email));
+        User user = UserServiceHelper.findExistingUser(userRepository, email);
         userRepository.save(user);
 
         sessionHandler.deduplicate(email); //중복 세션 제거

--- a/src/main/java/com/map/gaja/oauth2/handler/Oauth2FailureHandler.java
+++ b/src/main/java/com/map/gaja/oauth2/handler/Oauth2FailureHandler.java
@@ -1,0 +1,18 @@
+package com.map.gaja.oauth2.handler;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class Oauth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(410); //회원 탈퇴한 유저가 로그인할 경우 예외 응답
+    }
+}

--- a/src/main/java/com/map/gaja/user/application/AutoLoginProcessor.java
+++ b/src/main/java/com/map/gaja/user/application/AutoLoginProcessor.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.map.gaja.user.application.UserServiceHelper.findExistingUser;
+import static com.map.gaja.user.application.UserServiceHelper.findByEmailAndActive;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class AutoLoginProcessor {
      */
     @Transactional
     public AutoLoginResponse process(String email) {
-        User user = findExistingUser(userRepository, email);
+        User user = findByEmailAndActive(userRepository, email);
         user.updateLastLoginDate(); //최근 접속일 update
 
         Long referenceGroupId = user.getReferenceGroupId();

--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 
+import static com.map.gaja.user.application.UserServiceHelper.findByEmail;
 import static com.map.gaja.user.application.UserServiceHelper.findExistingUser;
 
 @Service
@@ -31,11 +32,9 @@ public class UserService {
             throw new UserNotFoundException();
         }
 
-        sessionHandler.deduplicate(email); //중복로그인 처리 최대 2개까지
+        User user = findByEmail(userRepository, email);
 
-        User user = userRepository.findByEmailAndActive(email)
-                .orElse(new User(email));
-        userRepository.save(user);
+        sessionHandler.deduplicate(email); //중복로그인 처리 최대 2개까지
 
         authenticationHandler.saveContext(email, user.getAuthority().toString()); //SecurityContextHolder에 인증 객체 저장
 

--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.format.DateTimeFormatter;
 
 import static com.map.gaja.user.application.UserServiceHelper.findByEmail;
-import static com.map.gaja.user.application.UserServiceHelper.findExistingUser;
+import static com.map.gaja.user.application.UserServiceHelper.findByEmailAndActive;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +45,7 @@ public class UserService {
     }
 
     public void withdrawal(String email) {
-        User user = findExistingUser(userRepository, email);
+        User user = findByEmailAndActive(userRepository, email);
 
         user.withdrawal();
     }

--- a/src/main/java/com/map/gaja/user/application/UserService.java
+++ b/src/main/java/com/map/gaja/user/application/UserService.java
@@ -3,7 +3,6 @@ package com.map.gaja.user.application;
 import com.map.gaja.global.authentication.AuthenticationHandler;
 import com.map.gaja.global.authentication.SessionHandler;
 import com.map.gaja.user.domain.exception.UserNotFoundException;
-import com.map.gaja.user.domain.model.Authority;
 import com.map.gaja.user.domain.model.User;
 import com.map.gaja.user.infrastructure.Oauth2Client;
 import com.map.gaja.user.infrastructure.UserRepository;
@@ -13,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import static com.map.gaja.user.application.UserServiceHelper.findExistingUser;
@@ -36,7 +33,7 @@ public class UserService {
 
         sessionHandler.deduplicate(email); //중복로그인 처리 최대 2개까지
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByEmailAndActive(email)
                 .orElse(new User(email));
         userRepository.save(user);
 

--- a/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
+++ b/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
@@ -6,7 +6,10 @@ import com.map.gaja.user.domain.model.User;
 import com.map.gaja.user.infrastructure.UserRepository;
 
 public final class UserServiceHelper {
-    public static User findExistingUser(UserRepository userRepository, String email) {
+    /**
+     * 회은 탈퇴 안 한 유저 조회
+     */
+    public static User findByEmailAndActive(UserRepository userRepository, String email) {
         return userRepository.findByEmailAndActive(email)
                 .orElseThrow(() -> {
                     throw new UserNotFoundException();

--- a/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
+++ b/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
@@ -6,7 +6,7 @@ import com.map.gaja.user.infrastructure.UserRepository;
 
 public final class UserServiceHelper {
     public static User findExistingUser(UserRepository userRepository, String email) {
-        return userRepository.findByEmail(email)
+        return userRepository.findByEmailAndActive(email)
                 .orElseThrow(() -> {
                     throw new UserNotFoundException();
                 });

--- a/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
+++ b/src/main/java/com/map/gaja/user/application/UserServiceHelper.java
@@ -1,6 +1,7 @@
 package com.map.gaja.user.application;
 
 import com.map.gaja.user.domain.exception.UserNotFoundException;
+import com.map.gaja.user.domain.exception.WithdrawalUserException;
 import com.map.gaja.user.domain.model.User;
 import com.map.gaja.user.infrastructure.UserRepository;
 
@@ -10,5 +11,36 @@ public final class UserServiceHelper {
                 .orElseThrow(() -> {
                     throw new UserNotFoundException();
                 });
+    }
+
+    /**
+     * 소셜 로그인 시 신규유저인지 회원 탈퇴 유저인지 판별
+     */
+    public static User findByEmail(UserRepository userRepository, String email) {
+        User user = userRepository.findByEmail(email);
+        if (isWithdrawalUser(user)) { //회원 탈퇴한 유저인가?
+            throw new WithdrawalUserException();
+        }
+
+        if (isNewUser(user)) { //신규 유저인가?
+            user = new User(email);
+            userRepository.save(user);
+        }
+
+        return user;
+    }
+
+    private static boolean isNewUser(User user) {
+        if (user == null) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean isWithdrawalUser(User user) {
+        if (user != null && !user.getActive()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/map/gaja/user/domain/exception/WithdrawalUserException.java
+++ b/src/main/java/com/map/gaja/user/domain/exception/WithdrawalUserException.java
@@ -1,0 +1,11 @@
+package com.map.gaja.user.domain.exception;
+
+import com.map.gaja.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class WithdrawalUserException extends BusinessException {
+
+    public WithdrawalUserException() {
+        super(HttpStatus.GONE, "회원 탈퇴를 처리하고 있는 유저입니다. (최대 하루 소요)");
+    }
+}

--- a/src/main/java/com/map/gaja/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/map/gaja/user/infrastructure/UserRepository.java
@@ -13,7 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * active가 활성화된 유저의 이메일 조회
      */
     @Query("SELECT u FROM User u WHERE u.email = :email AND u.active = true")
-    Optional<User> findByEmail(@Param(value = "email") String email);
+    Optional<User> findByEmailAndActive(@Param(value = "email") String email);
 
     /**
      * 회원탈퇴한 user 전부 삭제

--- a/src/main/java/com/map/gaja/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/map/gaja/user/infrastructure/UserRepository.java
@@ -21,4 +21,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query(value = "DELETE FROM User u WHERE u.active = false")
     int deleteWithdrawnUsers();
+
+    /**
+     * 이메일로 유저 조회
+     */
+    User findByEmail(String email);
 }

--- a/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
@@ -23,7 +23,8 @@ public interface UserApiSpecification {
             description = "카카오 액세스토큰을 이용한 로그인",
             responses = {
                     @ApiResponse(responseCode = "200", headers = {@Header(name = "Set-Cookie", description = "인증 토큰 ex) JSESSIONID =1231231232d", schema = @Schema(implementation = String.class))}, content = @Content(schema = @Schema(implementation = LoginResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
+                    @ApiResponse(responseCode = "410", description = "회원 탈퇴를 처리하고 있는 유저입니다. (최대 하루 소요)", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             }
     )
     ResponseEntity<LoginResponse> login(LoginRequest request);

--- a/src/main/java/com/map/gaja/user/presentation/web/WebUserLoginController.java
+++ b/src/main/java/com/map/gaja/user/presentation/web/WebUserLoginController.java
@@ -26,7 +26,7 @@ public class WebUserLoginController {
     public String loginSuccess(String loginEmail) {
         // 임시 로그인
         System.out.println(loginEmail);
-        User user = userRepository.findByEmail(loginEmail).get();
+        User user = userRepository.findByEmailAndActive(loginEmail).get();
 
         authenticationHandler.saveContext(loginEmail, user.getAuthority().toString());
         return "redirect:/";

--- a/src/test/java/com/map/gaja/group/application/GroupServiceTest.java
+++ b/src/test/java/com/map/gaja/group/application/GroupServiceTest.java
@@ -49,7 +49,7 @@ class GroupServiceTest {
                 .lastLoginDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
 
         assertThatThrownBy(() -> groupService.create(email, groupCreateRequest)).isInstanceOf(GroupLimitExceededException.class);
     }
@@ -61,7 +61,7 @@ class GroupServiceTest {
         GroupCreateRequest groupCreateRequest = new GroupCreateRequest("group");
         User user = new User(email);
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(groupRepository.save(any())).thenReturn(new Group("group", user));
 
         Long groupId = groupService.create(email, groupCreateRequest);
@@ -83,7 +83,7 @@ class GroupServiceTest {
                 .lastLoginDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(groupRepository.deleteByIdAndUserId(1L, 1L)).thenReturn(1);
 
         groupService.delete(email, 1L);
@@ -106,7 +106,7 @@ class GroupServiceTest {
                 .lastLoginDate(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
                 .build();
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(groupRepository.deleteByIdAndUserId(1L, 1L)).thenReturn(0);
 
         assertThatThrownBy(() -> {
@@ -130,7 +130,7 @@ class GroupServiceTest {
                 .build();
         GroupUpdateRequest request = new GroupUpdateRequest("test");
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(groupRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> {
@@ -154,7 +154,7 @@ class GroupServiceTest {
         GroupUpdateRequest request = new GroupUpdateRequest("test");
         Group group = new Group("name", user);
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(groupRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.of(group));
 
         groupService.updateName(email, 1L, request);

--- a/src/test/java/com/map/gaja/user/application/AutoLoginProcessorTest.java
+++ b/src/test/java/com/map/gaja/user/application/AutoLoginProcessorTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +38,7 @@ class AutoLoginProcessorTest {
         User user = new User(email);
         ClientListResponse clientListResponse = new ClientListResponse();
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(clientQueryService.findAllClient(email, null)).thenReturn(clientListResponse);
         autoLoginProcessor.process(email);
 
@@ -71,7 +70,7 @@ class AutoLoginProcessorTest {
             }
         };
 
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailAndActive(email)).thenReturn(Optional.of(user));
         when(groupRepository.findGroupInfoById(user.getReferenceGroupId())).thenReturn(groupInfo);
         when(clientQueryService.findAllClientsInGroup(groupInfo.getGroupId(), null)).thenReturn(clientListResponse);
         autoLoginProcessor.process(email);

--- a/src/test/java/com/map/gaja/user/application/UserServiceHelperTest.java
+++ b/src/test/java/com/map/gaja/user/application/UserServiceHelperTest.java
@@ -34,5 +34,15 @@ class UserServiceHelperTest {
 
     }
 
+    @Test
+    @DisplayName("신규 유저가 로그인할 경우")
+    void newUserLogin() {
+        String email = "test@gmail.com";
+
+        when(userRepository.findByEmail(email)).thenReturn(null);
+        UserServiceHelper.findByEmail(userRepository, email);
+
+        verify(userRepository, times(1)).save(any());
+    }
 
 }

--- a/src/test/java/com/map/gaja/user/application/UserServiceHelperTest.java
+++ b/src/test/java/com/map/gaja/user/application/UserServiceHelperTest.java
@@ -1,0 +1,38 @@
+package com.map.gaja.user.application;
+
+import com.map.gaja.user.domain.model.User;
+import com.map.gaja.user.infrastructure.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceHelperTest {
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    private UserServiceHelper userServiceHelper;
+
+    @Test
+    @DisplayName("회원 탈퇴한 유저가 로그인할 경우")
+    void withdrawalUserLogin() {
+        String email = "test@gmail.com";
+        User user = User.builder()
+                .email(email)
+                .active(false)
+                .build();
+
+        when(userRepository.findByEmail(email)).thenReturn(user);
+
+        assertThatThrownBy(()->userServiceHelper.findByEmail(userRepository, email));
+
+    }
+
+
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #290 

<!--
 전달할 내용
-->
## comment
- 회원 탈퇴한 유저가 로그인하면 **410**(_이 응답은 요청한 콘텐츠가 서버에서 영구적으로 삭제되었으며, 전달해 줄 수 있는 주소 역시 존재하지 않을 때_) 예외줌. 영구적으로 삭제된게 아니라 애매한데 제일 비슷해서 410줬음
- 웹 소셜 로그인 화면에서 410예외처리 해줘야 될듯 + 앱도 예외처리

<!--
 참고한 사이트
-->
## References
- 