### PR TITLE
고객 등록 시 수정 시 ClientOverview를 반환하도록 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -29,14 +29,14 @@ public class ClientConvertor {
         List<ClientOverviewResponse> responseClients = new ArrayList<>();
 
         clients.forEach(client -> {
-            ClientOverviewResponse clientResponse = entityToMultiOverviewDto(client);
+            ClientOverviewResponse clientResponse = entityToOverviewDto(client);
             responseClients.add(clientResponse);
         });
 
         return new ClientListResponse(responseClients, s3UrlGenerator.getS3Url());
     }
 
-    private static ClientOverviewResponse entityToMultiOverviewDto(Client client) {
+    protected static ClientOverviewResponse entityToOverviewDto(Client client) {
         return new ClientOverviewResponse(
                 client.getId(),
                 new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),
@@ -61,19 +61,6 @@ public class ClientConvertor {
                 voToDto(client.getLocation()),
                 image,
                 null,
-                client.getCreatedAt()
-        );
-    }
-
-    protected static ClientOverviewResponse entityToSingleOverviewDto(Client client, S3UrlGenerator s3UrlGenerator) {
-        return new ClientOverviewResponse(
-                client.getId(),
-                new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),
-                client.getName(),
-                client.getPhoneNumber(),
-                voToDto(client.getAddress()),
-                voToDto(client.getLocation()),
-                getStoredFileUrlDto(client.getClientImage(), s3UrlGenerator),
                 client.getCreatedAt()
         );
     }

--- a/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientConvertor.java
@@ -29,12 +29,26 @@ public class ClientConvertor {
         List<ClientOverviewResponse> responseClients = new ArrayList<>();
 
         clients.forEach(client -> {
-            ClientOverviewResponse clientResponse = entityToOverviewDto(client);
+            ClientOverviewResponse clientResponse = entityToMultiOverviewDto(client);
             responseClients.add(clientResponse);
         });
 
         return new ClientListResponse(responseClients, s3UrlGenerator.getS3Url());
     }
+
+    private static ClientOverviewResponse entityToMultiOverviewDto(Client client) {
+        return new ClientOverviewResponse(
+                client.getId(),
+                new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),
+                client.getName(),
+                client.getPhoneNumber(),
+                voToDto(client.getAddress()),
+                voToDto(client.getLocation()),
+                getStoredFileDto(client.getClientImage()),
+                client.getCreatedAt()
+        );
+    }
+
 
     protected static ClientDetailResponse entityToDetailDto(Client client, S3UrlGenerator s3UrlGenerator) {
         StoredFileDto image = getStoredFileUrlDto(client.getClientImage(), s3UrlGenerator);
@@ -51,7 +65,7 @@ public class ClientConvertor {
         );
     }
 
-    protected static ClientOverviewResponse entityToOverviewDto(Client client) {
+    protected static ClientOverviewResponse entityToSingleOverviewDto(Client client, S3UrlGenerator s3UrlGenerator) {
         return new ClientOverviewResponse(
                 client.getId(),
                 new GroupInfoDto(client.getGroup().getId(), client.getGroup().getName()),
@@ -59,7 +73,7 @@ public class ClientConvertor {
                 client.getPhoneNumber(),
                 voToDto(client.getAddress()),
                 voToDto(client.getLocation()),
-                getStoredFileDto(client.getClientImage()),
+                getStoredFileUrlDto(client.getClientImage(), s3UrlGenerator),
                 client.getCreatedAt()
         );
     }

--- a/src/main/java/com/map/gaja/client/apllication/ClientService.java
+++ b/src/main/java/com/map/gaja/client/apllication/ClientService.java
@@ -41,7 +41,6 @@ public class ClientService {
 
     private final ClientQueryRepository clientQueryRepository;
     private final IncreasingClientService increasingClientService;
-    private final S3UrlGenerator s3UrlGenerator;
 
 
     /**
@@ -55,7 +54,7 @@ public class ClientService {
         Client client = dtoToEntity(clientRequest, group);
         clientRepository.save(client);
         increasingClientService.increase(group, group.getUser().getAuthority(), 1);
-        return entityToSingleOverviewDto(client, s3UrlGenerator);
+        return entityToOverviewDto(client);
     }
 
     /**
@@ -71,7 +70,7 @@ public class ClientService {
         Client client = dtoToEntity(clientRequest, group, storedFileDto);
         clientRepository.save(client);
         increasingClientService.increase(group, group.getUser().getAuthority(), 1);
-        return entityToSingleOverviewDto(client, s3UrlGenerator);
+        return entityToOverviewDto(client);
     }
 
     public void deleteClient(long clientId) {
@@ -102,7 +101,7 @@ public class ClientService {
         }
         updateClientField(existingClient, updateRequest);
 
-        return entityToSingleOverviewDto(existingClient, s3UrlGenerator);
+        return entityToOverviewDto(existingClient);
     }
 
     /**
@@ -128,7 +127,7 @@ public class ClientService {
         existingClient.removeClientImage();
         existingClient.updateImage(clientImage);
 
-        return entityToSingleOverviewDto(existingClient, s3UrlGenerator);
+        return entityToOverviewDto(existingClient);
     }
 
     /**
@@ -144,7 +143,7 @@ public class ClientService {
         updateClientField(existingClient, updateRequest);
         existingClient.removeClientImage();
 
-        return entityToSingleOverviewDto(existingClient, s3UrlGenerator);
+        return entityToOverviewDto(existingClient);
     }
 
 

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -38,7 +38,6 @@ import javax.validation.Valid;
 public class ClientController implements ClientCommandApiSpecification {
 
     private final ClientService clientService;
-    private final ClientQueryService clientQueryService;
     private final ClientAccessVerifyService clientAccessVerifyService;
     private final GroupAccessVerifyService groupAccessVerifyService;
     private final S3FileService fileService;
@@ -143,6 +142,12 @@ public class ClientController implements ClientCommandApiSpecification {
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
+    /**
+     * ClientOverview를 반환하는 이유는
+     * 모바일에서 고객 등록 시에 바로 지도페이지로 넘어가기 때문에
+     * 반환받은 ClientOverview를 바로 리스트에 넣어서 사용해야 하기 때문이다.
+     * 저장된 프로필 이미지의 S3의 파일 경로와 생성된 고객 ID만 넘겨도 충분한가?
+     */
     @PostMapping("/clients")
     public ResponseEntity<ClientOverviewResponse> addClient(
             @AuthenticationPrincipal(expression = "name") String loginEmail,

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
@@ -54,18 +54,18 @@ public interface ClientCommandApiSpecification {
             @Valid @RequestBody ClientIdsRequest clientIdsRequest
     );
 
-    @Operation(summary = "고객 정보 변경", description = "form 형식으로 clientRequest 데이터를 전달해주세요",
+    @Operation(summary = "고객 정보 변경", description = "form 형식으로 clientRequest 데이터를 전달해주세요.",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
             },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "성공"),
+                    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorResponse.class)))),
                     @ApiResponse(responseCode = "415", description = "서버에서 지원하지 않는 파일 형식", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 그룹이 없거나, 그룹에 요청 고객이 없음 <br> 또는 그룹 내에 사용자 수보다 많은 사용자를 제거할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류로 이미지 저장 실패", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             })
-    ResponseEntity<Void> updateClient(
+    ResponseEntity<ClientOverviewResponse> updateClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @PathVariable Long groupId,
             @PathVariable Long clientId,
@@ -79,7 +79,7 @@ public interface ClientCommandApiSpecification {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
             },
             responses = {
-                    @ApiResponse(responseCode = "201", description = "성공 - 고객 ID 반환", content = @Content(schema = @Schema(implementation = Long.class))),
+                    @ApiResponse(responseCode = "201", description = "성공", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorResponse.class)))),
                     @ApiResponse(responseCode = "415", description = "서버에서 지원하지 않는 파일 형식", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 그룹이 없거나, 그룹에 요청 고객이 없음 <br> 또는 그룹 내에 사용자 수보다 많은 사용자를 등록할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),

--- a/src/test/java/com/map/gaja/client/apllication/ClientQueryServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientQueryServiceTest.java
@@ -107,8 +107,7 @@ class ClientQueryServiceTest {
             clientList.add(TestEntityCreator.createClient(i, testGroup1));
             clientList.add(TestEntityCreator.createClient(i, testGroup2));
         }
-        List<ClientOverviewResponse> testList = clientList.stream().map(ClientConvertor::entityToOverviewDto)
-                .collect(Collectors.toList());
+        List<ClientOverviewResponse> testList = ClientConvertor.entityToDto(clientList, s3UrlGenerator).getClients();
 
         when(userRepository.findByEmail(testEmail)).thenReturn(testUser);
         when(repository.findActiveClientByEmail(testEmail, null)).thenReturn(testList);
@@ -140,8 +139,7 @@ class ClientQueryServiceTest {
             clientList.add(TestEntityCreator.createClient(i, testGroup1));
             clientList.add(TestEntityCreator.createClient(i, testGroup2));
         }
-        List<ClientOverviewResponse> testList = clientList.stream().map(ClientConvertor::entityToOverviewDto)
-                .collect(Collectors.toList());
+        List<ClientOverviewResponse> testList = ClientConvertor.entityToDto(clientList, s3UrlGenerator).getClients();
 
         when(userRepository.findByEmail(testEmail)).thenReturn(testUser);
         when(groupQueryRepository.findActiveGroupId(testEmail)).thenReturn(groupIdList);

--- a/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
@@ -67,7 +67,6 @@ class ClientServiceTest {
     Group changedGroup;
     Client existingClient;
     ClientImage clientImage;
-    String s3Prefix = "my.s3.url/";
 
     @BeforeEach
     void beforeEach() {
@@ -77,8 +76,7 @@ class ClientServiceTest {
                 groupRepository,
                 groupQueryRepository,
                 clientQueryRepository,
-                increasingClientService,
-                s3UrlGenerator
+                increasingClientService
         );
 
         user = TestEntityCreator.createUser(email);
@@ -143,7 +141,6 @@ class ClientServiceTest {
 
         when(clientQueryRepository.findClientWithGroup(anyLong()))
                 .thenReturn(Optional.ofNullable(existingClient));
-        when(s3UrlGenerator.getS3Url()).thenReturn(s3Prefix);
 
         // when
         ClientOverviewResponse response = clientService.updateClientWithNewImage(existingClientId, changedRequest, updatedImageFile);
@@ -153,7 +150,7 @@ class ClientServiceTest {
 
         assertThat(response.getGroupInfo().getGroupId()).isEqualTo(existingGroup.getId());
         assertThat(response.getImage().getOriginalFileName()).isSameAs(updatedImageFile.getOriginalFileName());
-        assertThat(response.getImage().getFilePath()).isEqualTo(s3Prefix.concat(updatedImageFilePath));
+        assertThat(response.getImage().getFilePath()).isEqualTo(updatedImageFilePath);
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
@@ -4,8 +4,10 @@ import com.map.gaja.TestEntityCreator;
 import com.map.gaja.client.domain.model.ClientImage;
 import com.map.gaja.client.infrastructure.file.excel.ClientExcelDto;
 import com.map.gaja.client.infrastructure.repository.ClientBulkRepository;
+import com.map.gaja.client.infrastructure.s3.S3UrlGenerator;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleClientBulkRequest;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleNewClientRequest;
+import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.map.gaja.group.domain.model.Group;
@@ -28,6 +30,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -48,6 +51,8 @@ class ClientServiceTest {
     @Mock
     GroupQueryRepository groupQueryRepository;
     IncreasingClientService increasingClientService = new IncreasingClientService();
+    @Mock
+    S3UrlGenerator s3UrlGenerator;
 
     Long clientId = 1L;
     Long groupId = 1L;
@@ -62,6 +67,7 @@ class ClientServiceTest {
     Group changedGroup;
     Client existingClient;
     ClientImage clientImage;
+    String s3Prefix = "my.s3.url/";
 
     @BeforeEach
     void beforeEach() {
@@ -71,7 +77,8 @@ class ClientServiceTest {
                 groupRepository,
                 groupQueryRepository,
                 clientQueryRepository,
-                increasingClientService
+                increasingClientService,
+                s3UrlGenerator
         );
 
         user = TestEntityCreator.createUser(email);
@@ -117,11 +124,11 @@ class ClientServiceTest {
                 .thenReturn(Optional.ofNullable(changedGroup));
 
         // when
-        clientService.updateClientWithoutImage(existingClientId, changedRequest);
+        ClientOverviewResponse response = clientService.updateClientWithoutImage(existingClientId, changedRequest);
 
         // then
-        assertThat(existingClient.getName()).isEqualTo(changedName);
-        assertThat(existingClient.getGroup().getId()).isEqualTo(changedGroupId);
+        assertThat(response.getClientName()).isEqualTo(changedName);
+        assertThat(response.getGroupInfo().getGroupId()).isEqualTo(changedGroupId);
         assertThat(changedGroup.getClientCount()).isEqualTo(1);
         assertThat(existingGroup.getClientCount()).isEqualTo(0);
     }
@@ -130,21 +137,23 @@ class ClientServiceTest {
     @DisplayName("Client 이미지 업데이트 테스트")
     public void updateClientImageTest() throws Exception {
         // given
-        StoredFileDto updatedImageFile = new StoredFileDto("ccc", "ddd");
+        String updatedImageFilePath = UUID.randomUUID().toString();
+        StoredFileDto updatedImageFile = new StoredFileDto(updatedImageFilePath, "ddd");
         NewClientRequest changedRequest = createChangeRequest(existingGroup.getId(), existingName);
 
         when(clientQueryRepository.findClientWithGroup(anyLong()))
                 .thenReturn(Optional.ofNullable(existingClient));
+        when(s3UrlGenerator.getS3Url()).thenReturn(s3Prefix);
 
         // when
-        clientService.updateClientWithNewImage(existingClientId, changedRequest, updatedImageFile);
+        ClientOverviewResponse response = clientService.updateClientWithNewImage(existingClientId, changedRequest, updatedImageFile);
 
         // then
-        assertThat(existingClient.getGroup().getId()).isEqualTo(existingGroup.getId());
-        assertThat(existingClient.getClientImage().getOriginalName()).isSameAs(updatedImageFile.getOriginalFileName());
-        assertThat(existingClient.getClientImage().getSavedPath()).isSameAs(updatedImageFile.getFilePath());
-        assertThat(clientImage.getIsDeleted()).isTrue();
-        assertThat(existingClient.getClientImage().getIsDeleted()).isFalse();
+        assertThat(clientImage.getIsDeleted()).isTrue(); // 기존 이미지 삭제
+
+        assertThat(response.getGroupInfo().getGroupId()).isEqualTo(existingGroup.getId());
+        assertThat(response.getImage().getOriginalFileName()).isSameAs(updatedImageFile.getOriginalFileName());
+        assertThat(response.getImage().getFilePath()).isEqualTo(s3Prefix.concat(updatedImageFilePath));
     }
 
     @Test
@@ -152,17 +161,17 @@ class ClientServiceTest {
     public void updateClientWithBasicImageTest() throws Exception {
         // given
         NewClientRequest changedRequest = createChangeRequest(existingGroup.getId(), existingName);
-
         when(clientQueryRepository.findClientWithGroup(anyLong()))
                 .thenReturn(Optional.ofNullable(existingClient));
 
         // when
-        clientService.updateClientWithBasicImage(existingClientId, changedRequest);
+        ClientOverviewResponse response = clientService.updateClientWithBasicImage(existingClientId, changedRequest);
 
         // then
-        assertThat(existingClient.getGroup().getId()).isEqualTo(existingGroup.getId());
-        assertThat(clientImage.getIsDeleted()).isTrue();
-        assertThat(existingClient.getClientImage()).isNull();
+        assertThat(clientImage.getIsDeleted()).isTrue(); // 기존 이미지 삭제
+
+        assertThat(response.getGroupInfo().getGroupId()).isEqualTo(existingGroup.getId());
+        assertThat(response.getImage().getFilePath()).isNull();
     }
 
     @Test
@@ -180,12 +189,12 @@ class ClientServiceTest {
         int changedGroupClientCount = changedGroup.getClientCount();
 
         // when
-        clientService.updateClientWithBasicImage(existingClientId, changedRequest);
+        ClientOverviewResponse response = clientService.updateClientWithBasicImage(existingClientId, changedRequest);
 
         // then
-        assertThat(existingClient.getGroup().getId()).isEqualTo(existingGroup.getId());
         assertThat(clientImage.getIsDeleted()).isTrue();
-        assertThat(existingClient.getClientImage()).isNull();
+        assertThat(response.getGroupInfo().getGroupId()).isEqualTo(existingGroup.getId());
+        assertThat(response.getImage().getFilePath()).isNull();
 
         assertThat(existingGroup.getClientCount()).isEqualTo(existingGroupClientCount - 1);
         assertThat(changedGroup.getClientCount()).isEqualTo(changedGroupClientCount + 1);


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #312

<!--
 전달할 내용
-->
## comment
- 고객 등록 시 수정 시 ClientOverview를 반환하도록 수정


```java
ClientListResponse { 
  List<ClientOverviewResponse> list;
  String imagePrefix = "s3 경로" ;
}
```
기존에 `ClientOverviewResponse`는 `ClientListResponse`에 List형식으로 담겨서 나가면서 imagePrefix가 `ClientListReponse`에 붙었다.
근데 `ClientListReponse`가 아닌 `ClientOverview`를 단일로 내보내면 `ClientOverview`에 imagePrefix를 붙혀서 절대경로로 보내줘야한다.
물론 이 문제는 해결했다.

근데 문제는 ClientOverview에 데이터에 일관성이 사라졌다.
반경 검색 또는 그룹내의 고객 검색을 할 때는 ClientOverview.getFilePath를 하면 상대경로가 나오는데
고객 등록 또는 수정을 할 때는 ClientOverview.getFilePath를 하면 절대경로(s3경로+상대경로)가 나온다.

예시
상대경로: `example3@test.com/uuid-123456.png`
절대경로: `https://aaa.s3.bbb.amazonaws.com/example3@test.com/uuid-123456.png`

상인 너가 말했듯이 image 경로와 ID만 주는 것도 좋아보인다.

<!--
 참고한 사이트
-->
## References
- 