### PR TITLE
Feat/#322 Client 관련 커스텀 메트릭 추가

### DIFF
--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -17,6 +17,7 @@ import com.map.gaja.client.infrastructure.s3.S3FileService;
 import com.map.gaja.client.presentation.dto.access.ClientAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
+@Timed("client.modify")
 @Slf4j
 @TimeCheckLog
 @RestController

--- a/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetClientController.java
@@ -5,6 +5,7 @@ import com.map.gaja.client.presentation.api.specification.ClientQueryApiSpecific
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
 import com.map.gaja.global.log.TimeCheckLog;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
+@Timed("client.search")
 @TimeCheckLog
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/GetGroupClientController.java
@@ -9,6 +9,8 @@ import com.map.gaja.client.apllication.ClientQueryService;
 import com.map.gaja.client.presentation.dto.access.ClientAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.NearbyClientSearchRequest;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import javax.validation.Valid;
  * ReadOnly Client 컨트롤러
  */
 @TimeCheckLog
+@Timed("client.search")
 @RestController
 @RequiredArgsConstructor
 public class GetGroupClientController implements GroupClientQueryApiSpecification {

--- a/src/main/java/com/map/gaja/global/config/MonitoringConfig.java
+++ b/src/main/java/com/map/gaja/global/config/MonitoringConfig.java
@@ -1,0 +1,21 @@
+package com.map.gaja.global.config;
+
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitoringConfig {
+    @Bean
+    public CountedAspect countedAspect(MeterRegistry registry) {
+        return new CountedAspect(registry);
+    }
+
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry registry) {
+        return new TimedAspect(registry);
+    }
+
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #322 

<!--
 전달할 내용
-->
## comment
- 가장 오래 걸린 응답 시간, 1분당 평균 응답 시간, 1분당 요청 수 모니터링 가능하도록 메트릭 추가
![image](https://github.com/GaJaMap/backend/assets/88225377/fd1ca633-8b1e-4e7b-99d1-e5e7cb8ce82f)


<!--
 참고한 사이트
-->
## References
- https://velog.io/@sdsd0908/%EC%8A%A4%ED%94%84%EB%A7%81-%EB%AA%A8%EB%8B%88%ED%84%B0%EB%A7%81-2-%EC%BB%A4%EC%8A%A4%ED%85%80-%EB%A9%94%ED%8A%B8%EB%A6%AD-%EB%A7%8C%EB%93%A4%EA%B8%B0
관련 글 정리함