### PR TITLE
Fix/#316 전화번호부 or 카카오로 고객 등록 시 등록된 아이디 리스트를 반환하도록 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -1,13 +1,11 @@
 package com.map.gaja.client.presentation.api;
 
-import com.map.gaja.client.apllication.ClientQueryService;
 import com.map.gaja.client.infrastructure.file.FileValidator;
 import com.map.gaja.client.infrastructure.file.exception.FileNotAllowedException;
 import com.map.gaja.client.presentation.api.specification.ClientCommandApiSpecification;
 import com.map.gaja.client.presentation.dto.access.ClientListAccessCheckDto;
 import com.map.gaja.client.presentation.dto.request.ClientIdsRequest;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleClientBulkRequest;
-import com.map.gaja.client.presentation.dto.response.ClientDetailResponse;
 import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.global.log.TimeCheckLog;
 import com.map.gaja.group.application.GroupAccessVerifyService;
@@ -30,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @Timed("client.modify")
 @Slf4j
@@ -134,14 +133,14 @@ public class ClientController implements ClientCommandApiSpecification {
     }
 
     @PostMapping("/clients/bulk")
-    public ResponseEntity<Void> addSimpleBulkClient(
+    public ResponseEntity<List<Long>> addSimpleBulkClient(
             @AuthenticationPrincipal(expression = "name") String loginEmail,
             @Valid @RequestBody SimpleClientBulkRequest clientBulkRequest
     ) {
         // 단순한 Client 정보 등록
         groupAccessVerifyService.verifyGroupAccess(clientBulkRequest.getGroupId(), loginEmail);
-        clientService.saveSimpleClientList(clientBulkRequest);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        List<Long> response = clientService.saveSimpleClientList(clientBulkRequest);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     /**

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
@@ -21,6 +21,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 public interface ClientCommandApiSpecification {
 
@@ -100,7 +101,7 @@ public interface ClientCommandApiSpecification {
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorResponse.class)))),
                     @ApiResponse(responseCode = "422", description = "사용자에게 요청 그룹이 없거나, 그룹에 요청 고객이 없음 <br> 또는 그룹 내에 사용자 수보다 많은 사용자를 등록할 수 없음", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             })
-    public ResponseEntity<Void> addSimpleBulkClient(
+    public ResponseEntity<List<Long>> addSimpleBulkClient(
             @Schema(hidden = true) @AuthenticationPrincipal String loginEmail,
             @Valid @RequestBody SimpleClientBulkRequest clientBulkRequest
     );

--- a/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
+++ b/src/test/java/com/map/gaja/client/apllication/ClientServiceTest.java
@@ -248,6 +248,14 @@ class ClientServiceTest {
         long beforeClientCount = existingGroup.getClientCount();
         when(groupQueryRepository.findGroupWithUser(existingGroup.getId()))
                 .thenReturn(Optional.ofNullable(existingGroup));
+        when(clientRepository.saveAll(any())).thenAnswer(invocation -> {
+            List<Client> savedClient = invocation.getArgument(0); // 저장되는 클라이언트 객체
+            long tempId = 1;
+            for (Client client : savedClient) {
+                ReflectionTestUtils.setField(client, "id", tempId++);
+            }
+            return savedClient;
+        });
 
         SimpleClientBulkRequest bulkRequest = new SimpleClientBulkRequest(existingGroup.getId(), clients);
         clientService.saveSimpleClientList(bulkRequest);


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #316 

<!--
 전달할 내용
-->
## comment
- 전화번호부 or 카카오로 고객 등록 시 등록된 아이디 리스트를 반환하도록 수정
사유: 모바일 진행을 위해

나중에 모바일에 새로고침 기능이 개발되면 그땐 해당 Merge기록 자체를 없애버리기

<!--
 참고한 사이트
-->
## References
- 