### PR TITLE
fix: 페이징 size를 VIP 등급이 생성할 수 있는 최대 그룹 수만큼 설정

### DIFF
--- a/src/main/java/com/map/gaja/group/presentation/api/GroupController.java
+++ b/src/main/java/com/map/gaja/group/presentation/api/GroupController.java
@@ -37,7 +37,7 @@ public class GroupController implements GroupApiSpecification {
 
     @Override
     @GetMapping
-    public ResponseEntity<GroupResponse> read(@AuthenticationPrincipal(expression = "userId") Long userId, @PageableDefault Pageable pageable) {
+    public ResponseEntity<GroupResponse> read(@AuthenticationPrincipal(expression = "userId") Long userId, @PageableDefault(size = 100) Pageable pageable) {
         GroupResponse response = groupService.findGroups(userId, pageable);
 
         return new ResponseEntity<>(response, HttpStatus.OK);


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #345 

<!--
 전달할 내용
-->
## comment
- 나중에 앱에서 페이징 기능 추가되면 쉽게 변경하기 위해 Pageable default size만 100(VIP등급 그룹 생성 제한 수) 으로 설정해줌. 근데 100개밖에 없으니깐 페이징 기능없어도 될 것 같긴함.

<!--
 참고한 사이트
-->
## References
- 