### PR TITLE
단일 고객 삭제 시 오류 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
@@ -51,7 +51,6 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
      */
     @Query("SELECT c FROM Client c " +
             "JOIN FETCH c.group g " +
-            "LEFT JOIN FETCH c.clientImage ci " +
             "WHERE c.id = :clientId AND g.isDeleted = false")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Client> findClientWithGroupForUpdate(long clientId);


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #374 

<!--
 전달할 내용
-->
## comment
- 고객 이미지가 있을 수도 있고, 없을 수도 있다. 하지만 쿼리에 lock이 걸렸을 때 Outer Join 불가능
- Outer Join으로 한 번에 가져오기 않고, 이미지가 있다면 Lazy 로딩으로 쿼리 한 번 더 날려서 가져오도록 변경

<!--
 참고한 사이트
-->
## References
- 