### PR TITLE
로그인이 되어도 Login 페이지 표시되는 문제 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,8 @@ task testCoverage(type: Test) {
 
 task testOnlyJava(type: Test) {
 	useJUnitPlatform {
-		{
-			exclude("/**/*RepositoryTest.class")
-		}
+		exclude("/**/*RepositoryTest.class")
+		exclude("/**/GajaApplicationTests.class")
 	}
 }
 

--- a/src/main/java/com/map/gaja/user/presentation/web/WebUserLoginController.java
+++ b/src/main/java/com/map/gaja/user/presentation/web/WebUserLoginController.java
@@ -1,10 +1,12 @@
 package com.map.gaja.user.presentation.web;
 
 import com.map.gaja.global.authentication.AuthenticationHandler;
+import com.map.gaja.global.authentication.PrincipalDetails;
 import com.map.gaja.global.log.TimeCheckLog;
 import com.map.gaja.user.domain.model.User;
 import com.map.gaja.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,14 +20,18 @@ public class WebUserLoginController {
     private final AuthenticationHandler authenticationHandler;
 
     @GetMapping("/login")
-    public String login() {
+    public String login(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        if (principalDetails != null) {
+            return "redirect:/";
+        }
+
         return "login";
     }
 
-//    @PostMapping("/testLogin")
-//    public String loginSuccess(String loginEmail) {
+//    @GetMapping("/testLogin")
+//    public String loginSuccess() {
 //        // 임시 로그인
-//        System.out.println(loginEmail);
+//        String loginEmail = "email3@example.com";
 //        User user = userRepository.findByEmailAndActive(loginEmail).get();
 //
 //        authenticationHandler.saveContext(user.getId(), loginEmail, user.getAuthority().toString());


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #381 

<!--
 전달할 내용
-->
## comment
- 로그인을 해도 /login 페이지가 계속 되는 현상이 있었다.
`@AuthenticationPrincipal PrincipalDetails principalDetails` 
지금 이 객체를 null 체크를 하는데
인증안된 사용자, 로그아웃한 사용자, 탈퇴한 사용자 등등의 정보가 다 null로 되는게 맞는거지?

- testOnlyJava 작업 수행시에 스프링 없이 젠킨스에서 순수 자바코드만 테스트할 수 있도록 
`@SpringBootTest`가 있는 `GajaApplicationTests`도 제외시킴

<!--
 참고한 사이트
-->
## References
- 