### PR TITLE
fix: 회원 탈퇴한 유저가 로그인할 경우 생성되는 익명 세션 제거

### DIFF
--- a/src/main/java/com/map/gaja/global/oauth2/handler/Oauth2FailureHandler.java
+++ b/src/main/java/com/map/gaja/global/oauth2/handler/Oauth2FailureHandler.java
@@ -7,12 +7,18 @@ import org.springframework.stereotype.Component;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
 @Component
 public class Oauth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        HttpSession session = request.getSession();
+        if (session != null) { //익명 세션 제거
+            session.invalidate();
+        }
+
         response.setStatus(410); //회원 탈퇴한 유저가 로그인할 경우 예외 응답
     }
 }


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #380 

<!--
 전달할 내용
-->
## comment
- `Oauth2FailureHandler.class` 는 OAuth 로그인 실패 핸들러인데 session이 있다면 익명 세션이 생성되니깐 저 클래스에서 세션을  제거함

<!--
 참고한 사이트
-->
## References
- 