### PR TITLE
DB에 임시 이미지 URL을 저장한 후 S3를 저장하는 방식으로 변경

### DIFF
--- a/src/main/java/com/map/gaja/client/infrastructure/s3/S3FileService.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/s3/S3FileService.java
@@ -144,6 +144,8 @@ public class S3FileService {
 
     private String extractExt(String originalFilename) {
         int pos = originalFilename.lastIndexOf(".");
+        if(pos == -1) // 확장자를 파악할 수 없는 파일
+            throw new InvalidFileException();
         return originalFilename.substring(pos + 1);
     }
 }

--- a/src/main/java/com/map/gaja/client/infrastructure/s3/S3FileService.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/s3/S3FileService.java
@@ -144,8 +144,10 @@ public class S3FileService {
 
     private String extractExt(String originalFilename) {
         int pos = originalFilename.lastIndexOf(".");
-        if(pos == -1) // 확장자를 파악할 수 없는 파일
+        if(pos == -1){ // 확장자를 파악할 수 없는 파일
+            log.info("확장자를 파악할 수 없는 파일 - 파일명 : {}", originalFilename);
             throw new InvalidFileException();
+        }
         return originalFilename.substring(pos + 1);
     }
 }

--- a/src/main/java/com/map/gaja/client/infrastructure/s3/S3FileService.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/s3/S3FileService.java
@@ -1,6 +1,5 @@
 package com.map.gaja.client.infrastructure.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.*;
 import com.map.gaja.client.domain.exception.InvalidFileException;
@@ -19,10 +18,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
- * 저장경로: /{파일확장자}/{uuid}.{파일확장자}
+ * 저장경로: /{이메일}/{uuid}.{파일확장자}
  * 파일 확장자 하위로 저장한다.
  */
 @Slf4j
@@ -36,19 +34,41 @@ public class S3FileService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public StoredFileDto storeFile(String loginEmail, MultipartFile file) {
-        try (InputStream fileInputStream = file.getInputStream()) {
-            String s3FileUrl = storeFileToS3(loginEmail, file, fileInputStream);
-            log.info("저장 완료. S3 저장위치 = {}", s3FileUrl);
+    /**
+     * DB 저장 하기위한 임시 저장 파일 정보
+     * 임시 저장 정보를 만들었다면 DB 저장 후
+     * 반드시 storeFile(...)메소드를 호출해서 실제로 저장해주어야 한다.
+     */
+    public StoredFileDto createTemporaryFileDto(String loginEmail, MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String storePath = createFilePath(loginEmail, originalFilename);
+        return new StoredFileDto(storePath, file.getOriginalFilename());
+    }
 
-            return createStoredFileDto(s3FileUrl, file.getOriginalFilename());
+    public void storeFile(StoredFileDto storedFileDto, MultipartFile file) {
+        try (InputStream fileInputStream = file.getInputStream()) {
+            String s3FileUrl = storeFileToS3(storedFileDto, file, fileInputStream);
+            log.info("저장 완료. S3 저장위치 = {}", s3FileUrl);
+//            log.info("저장 완료. S3 저장위치 = {}", s3FileUrl);
         } catch (RuntimeException e) {
             log.error("S3 문제로 파일 저장 실패", e);
             throw new S3NotWorkingException(e);
         } catch (IOException e) {
-            log.warn("파일 문제로 저장 실패 file={}", file);
+            log.warn("파일 문제로 저장 실패 file={}", file, e);
             throw new InvalidFileException(e);
         }
+    }
+
+    /**
+     * 파일 저장 후 파일 저장 위치 URL 반환
+     */
+    private String storeFileToS3(StoredFileDto storedFileDto, MultipartFile file, InputStream fileInputStream) {
+        ObjectMetadata objectMetadata = getFileMetadata(file);
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, storedFileDto.getFilePath(), fileInputStream, objectMetadata)
+        );
+
+        return decodePath(amazonS3Client.getUrl(bucket, storedFileDto.getFilePath()).toString());
     }
 
     public boolean removeFile(String s3ObjectUri) {
@@ -99,25 +119,6 @@ public class S3FileService {
         return amazonS3Client.doesObjectExist(bucket, filePath);
     }
 
-    private StoredFileDto createStoredFileDto(String s3FileUrl, String originalFilename) {
-        String filePath = extractFilePath(s3FileUrl);
-        return new StoredFileDto(filePath, originalFilename);
-    }
-
-    private String storeFileToS3(String loginEmail, MultipartFile file, InputStream fileInputStream) {
-        String originalFilename = file.getOriginalFilename();
-        String storePath = createFilePath(loginEmail, originalFilename);
-
-        ObjectMetadata objectMetadata = getFileMetadata(file);
-
-        amazonS3Client.putObject(
-                new PutObjectRequest(bucket, storePath, fileInputStream, objectMetadata)
-        );
-
-        String storedPath = amazonS3Client.getUrl(bucket, storePath).toString();
-        return decodePath(storedPath);
-    }
-
     private String decodePath(String storedPath) {
         return URLDecoder.decode(storedPath, StandardCharsets.UTF_8);
     }
@@ -144,9 +145,5 @@ public class S3FileService {
     private String extractExt(String originalFilename) {
         int pos = originalFilename.lastIndexOf(".");
         return originalFilename.substring(pos + 1);
-    }
-
-    private String extractFilePath(String s3FileUrl) {
-        return s3UrlGenerator.extractFilePath(s3FileUrl);
     }
 }

--- a/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/specification/ClientCommandApiSpecification.java
@@ -61,6 +61,7 @@ public interface ClientCommandApiSpecification {
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
+                    @ApiResponse(responseCode = "206", description = "부분 성공 - 이미지 저장은 실패. DB에 저장 실패한 URL이 반환되기 때문에 사용자에게 변경을 권유해야함", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorResponse.class)))),
                     @ApiResponse(responseCode = "403", description = "Free 등급 사용자 이미지 업로드 제한", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
                     @ApiResponse(responseCode = "415", description = "서버에서 지원하지 않는 파일 형식", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
@@ -82,6 +83,7 @@ public interface ClientCommandApiSpecification {
             },
             responses = {
                     @ApiResponse(responseCode = "201", description = "성공", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
+                    @ApiResponse(responseCode = "206", description = "부분 성공 - 이미지 저장은 실패. DB에 저장 실패한 URL이 반환되기 때문에 사용자에게 변경을 권유해야함", content = @Content(schema = @Schema(implementation = ClientOverviewResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ValidationErrorResponse.class)))),
                     @ApiResponse(responseCode = "403", description = "그룹 제한 고객 수 초과 or Free 등급 사용자 이미지 업로드 제한", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),
                     @ApiResponse(responseCode = "415", description = "서버에서 지원하지 않는 파일 형식", content = @Content(schema = @Schema(implementation = ExceptionDto.class))),

--- a/src/test/java/com/map/gaja/client/infrastructure/s3/S3FileServiceTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/s3/S3FileServiceTest.java
@@ -98,6 +98,25 @@ class S3FileServiceTest {
         assertThrows(S3NotWorkingException.class, () -> s3FileService.removeFile(s3ObjectUri));
     }
 
+    @Test
+    @DisplayName("임시 DTO 생성 테스트")
+    void createTemporaryFileDtoTest() {
+        MockMultipartFile mockFile = createMockFile();
+        StoredFileDto temporaryFileDto = s3FileService.createTemporaryFileDto(loginEmail, mockFile);
+
+        assertThat(temporaryFileDto.getOriginalFileName()).isEqualTo(mockFile.getOriginalFilename());
+        assertThat(temporaryFileDto.getFilePath()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("임시 DTO 생성 중 파일 확장자 식별 불가 에러")
+    void createTemporaryFileDtoFailTest() {
+        String fileNameWithoutExtension = "MallFileName";
+        assertThrows(InvalidFileException.class,
+                () -> s3FileService.createTemporaryFileDto(loginEmail, createMockFile(fileNameWithoutExtension))
+        );
+    }
+
     private MockMultipartFile createMockFile() {
         return new MockMultipartFile(
                 "file",
@@ -106,4 +125,15 @@ class S3FileServiceTest {
                 "test image files".getBytes()
         );
     }
+
+    private MockMultipartFile createMockFile(String fileName) {
+        return new MockMultipartFile(
+                "file",
+                fileName,
+                "image/jpeg",
+                "test image files".getBytes()
+        );
+    }
+
+
 }

--- a/src/test/java/com/map/gaja/client/infrastructure/s3/S3FileServiceTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/s3/S3FileServiceTest.java
@@ -48,25 +48,25 @@ class S3FileServiceTest {
     @DisplayName("파일 정상 저장")
     void storeFileTest() throws MalformedURLException {
         MockMultipartFile mockFile = createMockFile();
+        StoredFileDto fileDto = new StoredFileDto("test-Path", "test-image.png");
 
         when(awsS3Client.putObject(any())).thenReturn(null);
         when(awsS3Client.getUrl(any(), any())).thenReturn(new URL(s3FileUrl));
-        when(s3UrlGenerator.extractFilePath(any())).thenReturn(s3ObjectUri);
 
-        StoredFileDto result = s3FileService.storeFile(loginEmail, mockFile);
-
-        assertThat(result.getFilePath()).isEqualTo(s3ObjectUri);
-        assertThat(result.getOriginalFileName()).isEqualTo(originalFileName);
+        s3FileService.storeFile(fileDto, mockFile);
+        verify(awsS3Client, times(1)).putObject(any());
+        verify(awsS3Client, times(1)).getUrl(any(), any());
     }
 
     @Test
     @DisplayName("잘못된 파일이 들어옴")
     void storeInvalidFileTest() throws IOException {
         MockMultipartFile mockFile = Mockito.mock(MockMultipartFile.class);
+        StoredFileDto fileDto = new StoredFileDto("test-Path", "test-image.png");
 
         when(mockFile.getInputStream()).thenThrow(IOException.class);
 
-        assertThrows(InvalidFileException.class, () -> s3FileService.storeFile(loginEmail, mockFile));
+        assertThrows(InvalidFileException.class, () -> s3FileService.storeFile(fileDto, mockFile));
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
@@ -93,20 +93,18 @@ public class ClientPostControllerTest {
     }
 
     @Test
-    @DisplayName("이미지와 함께 고객 저장 중 오류 발생")
+    @DisplayName("이미지와 함께 고객 저장 중 DB 오류 발생")
     void addClientWithImageExceptionTest() throws Exception {
         String testUrl = "/api/clients";
         NewClientRequest request = ClientRequestCreator.createValidNewRequest(groupId);
         MockHttpServletRequestBuilder mockRequest = ClientRequestCreator.createPostRequestWithImage(testUrl);
         ClientRequestCreator.setNormalField(mockRequest, request);
         mockRequest.param("isBasicImage", String.valueOf(false));
-        StoredFileDto savedS3TestFile = new StoredFileDto("testFile-uuid", "testFile");
-        when(fileService.storeFile(any(), any())).thenReturn(savedS3TestFile);
         when(clientService.saveClientWithImage(any(), any())).thenThrow(new GroupNotFoundException());
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity());
         verify(clientService, times(1)).saveClientWithImage(any(), any());
-        verify(fileService, times(1)).removeFile(savedS3TestFile.getFilePath());
+        verify(fileService, times(1)).createTemporaryFileDto(any(),any());
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.map.gaja.client.application.ClientAccessVerifyService;
 import com.map.gaja.client.application.ClientQueryService;
 import com.map.gaja.client.application.ClientService;
+import com.map.gaja.client.domain.exception.InvalidFileException;
 import com.map.gaja.client.infrastructure.s3.S3FileService;
 import com.map.gaja.client.application.validator.ClientRequestValidator;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
@@ -77,6 +78,20 @@ public class ClientPostControllerTest {
         mockRequest.param("isBasicImage", String.valueOf(true));
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isCreated());
+    }
+
+    @Test
+    @DisplayName("이미지와 함께 고객 등록 중 이미지 예외")
+    void addClientWithImageFailTest() throws Exception {
+        String testUrl = "/api/clients";
+        NewClientRequest request = ClientRequestCreator.createValidNewRequest(groupId);
+        MockHttpServletRequestBuilder mockRequest = ClientRequestCreator.createPostRequestWithImage(testUrl);
+        ClientRequestCreator.setNormalField(mockRequest, request);
+        doThrow(InvalidFileException.class).when(fileService).storeFile(any(),any());
+        mockRequest.param("isBasicImage", String.valueOf(false));
+
+        mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isPartialContent());
+        verify(clientService, times(1)).saveClientWithImage(any(), any());
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPutControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPutControllerTest.java
@@ -87,12 +87,11 @@ public class ClientPutControllerTest {
         mockRequest.param("isBasicImage", String.valueOf(false));
 
         StoredFileDto savedS3TestFile = new StoredFileDto("testFile-uuid", "testFile");
-        when(fileService.storeFile(any(), any())).thenReturn(savedS3TestFile);
         doThrow(new ClientNotFoundException()).when(clientService).updateClientWithNewImage(any(), any(),any());
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity());
         verify(clientService, times(1)).updateClientWithNewImage(any(), any(), any());
-        verify(fileService, times(1)).removeFile(savedS3TestFile.getFilePath());
+        verify(fileService, times(1)).createTemporaryFileDto(any(), any());
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPutControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPutControllerTest.java
@@ -5,6 +5,7 @@ import com.map.gaja.client.application.ClientAccessVerifyService;
 import com.map.gaja.client.application.ClientQueryService;
 import com.map.gaja.client.application.ClientService;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
+import com.map.gaja.client.domain.exception.InvalidFileException;
 import com.map.gaja.client.infrastructure.s3.S3FileService;
 import com.map.gaja.client.application.validator.ClientRequestValidator;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
@@ -78,15 +79,25 @@ public class ClientPutControllerTest {
     }
 
     @Test
+    @DisplayName("고객 이미지 변경 중 이미지 예외")
+    void updateClientOtherImageFail() throws Exception {
+        NewClientRequest request = ClientRequestCreator.createValidNewRequest(groupId);
+        MockHttpServletRequestBuilder mockRequest = ClientRequestCreator.createPutRequestWithImage(testUri, groupId, clientId);
+        ClientRequestCreator.setNormalField(mockRequest, request);
+        doThrow(InvalidFileException.class).when(fileService).storeFile(any(),any());
+        mockRequest.param("isBasicImage", String.valueOf(false));
+
+        mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isPartialContent());
+        verify(clientService, times(1)).updateClientWithNewImage(any(), any(), any());
+    }
+
+    @Test
     @DisplayName("고객 이미지 DB 변경 중 예외")
     void updateClientOtherImageException() throws Exception {
         NewClientRequest request = ClientRequestCreator.createValidNewRequest(groupId);
-
         MockHttpServletRequestBuilder mockRequest = ClientRequestCreator.createPutRequestWithImage(testUri, groupId, clientId);
         ClientRequestCreator.setNormalField(mockRequest, request);
         mockRequest.param("isBasicImage", String.valueOf(false));
-
-        StoredFileDto savedS3TestFile = new StoredFileDto("testFile-uuid", "testFile");
         doThrow(new ClientNotFoundException()).when(clientService).updateClientWithNewImage(any(), any(),any());
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity());


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #409
이슈에 써져있는 흐름으로 로직을 변경하고 관련 테스트 코드 추가했다.

S3에서 오류가 발생하거나 파일에 문제가 있어서 
(고객 정보 저장 성공 + 이미지 저장 실패)한 경우
DB에는 S3에 저장되지 않은 UUID가 있으나 그냥 프론트로 반환해줌.
프론트에서 기존 이미지를 삭제하고 다시 등록하라고 말해줘야 할 듯
성공의 경우 : 201 CREATED, 200 OK
이미지만 실패인 경우 : 206 PARTIAL_CONTENT

<!--
 전달할 내용
-->
## comment
- 

<!--
 참고한 사이트
-->
## References
- 