### PR TITLE
Fix/#418 ClientImage에서 UUID를 생성하도록 수정

### DIFF
--- a/src/main/java/com/map/gaja/client/application/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/application/ClientConvertor.java
@@ -102,20 +102,6 @@ public class ClientConvertor {
         );
     }
 
-    protected static Client dtoToEntity(NewClientRequest request, Group group, StoredFileDto storedFileDto) {
-        AddressDto address = request.getAddress();
-        LocationDto location = request.getLocation();
-        ClientImage clientImage = new ClientImage(storedFileDto.getOriginalFileName(), storedFileDto.getFilePath());
-        return new Client(
-                request.getClientName(),
-                request.getPhoneNumber(),
-                dtoToVo(address),
-                dtoToVo(location),
-                group,
-                clientImage
-        );
-    }
-
     protected static ClientLocation dtoToVo(LocationDto location) {
         return (location == null || location.getLongitude() == null || location.getLatitude() == null) ? new ClientLocation() :
                 new ClientLocation(location.getLatitude(), location.getLongitude());

--- a/src/main/java/com/map/gaja/client/application/ClientService.java
+++ b/src/main/java/com/map/gaja/client/application/ClientService.java
@@ -1,5 +1,6 @@
 package com.map.gaja.client.application;
 
+import com.map.gaja.client.domain.model.ClientImage;
 import com.map.gaja.client.infrastructure.file.parser.dto.ParsedClientDto;
 import com.map.gaja.client.infrastructure.repository.ClientBulkRepository;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleClientBulkRequest;
@@ -56,12 +57,15 @@ public class ClientService {
      * 이미지와 함께 고객 등록
      *
      * @param clientRequest 고객 등록 요청 정보
-     * @param storedFileDto S3에 저장된 이미지 저장 정보
-     * @return 만들어진 고객 ID
+     * @param loginEmail 요청을 보내는 사용자 이메일
+     * @return 만들어진 고객
      */
-    public ClientOverviewResponse saveClientWithImage(NewClientRequest clientRequest, StoredFileDto storedFileDto) {
+    public ClientOverviewResponse saveClientWithImage(NewClientRequest clientRequest, String loginEmail) {
         Group group = GroupServiceHelper.findGroupByIdForUpdating(groupRepository, clientRequest.getGroupId());
-        Client client = dtoToEntity(clientRequest, group, storedFileDto);
+        ClientImage clientImage = ClientImage.create(loginEmail, clientRequest.getClientImage().getOriginalFilename());
+        Client client = dtoToEntity(clientRequest, group);
+        client.updateImage(clientImage);
+
         clientRepository.save(client);
         increasingClientService.increaseByOne(group, securityUserGetter.getAuthority().get(0));
         return entityToOverviewDto(client);

--- a/src/main/java/com/map/gaja/client/application/ClientService.java
+++ b/src/main/java/com/map/gaja/client/application/ClientService.java
@@ -105,19 +105,21 @@ public class ClientService {
      * 고객 + 고객 이미지 정보 변경
      * @param existingClientId 기존 고객 ID
      * @param updateRequest    고객 업데이트 요청 정보
-     * @param updatedFileDto   고객 이미지 업데이트 정보
+     * @param loginEmail   요청 사용자 이메일
      */
     public ClientOverviewResponse updateClientWithNewImage(
             Long existingClientId,
             NewClientRequest updateRequest,
-            StoredFileDto updatedFileDto
+            String loginEmail
     ) {
         Client existingClient = clientQueryRepository.findClientWithImage(existingClientId)
                 .orElseThrow(() -> new ClientNotFoundException());
+        ClientImage newImage = ClientImage.create(loginEmail, updateRequest.getClientImage().getOriginalFilename());
 
         updateClientGroupIfChanged(updateRequest, existingClient);
         ClientUpdater.updateClient(existingClient, updateRequest);
-        ClientUpdater.updateClientImage(existingClient, updatedFileDto);
+        existingClient.removeClientImage();
+        existingClient.updateImage(newImage);
 
         return entityToOverviewDto(existingClient);
     }

--- a/src/main/java/com/map/gaja/client/application/ClientUpdater.java
+++ b/src/main/java/com/map/gaja/client/application/ClientUpdater.java
@@ -24,13 +24,4 @@ public class ClientUpdater {
                 updatedLocation
         );
     }
-
-    /**
-     * ClientImage 업데이트
-     */
-    protected static void updateClientImage(Client existingClient, StoredFileDto updatedFileDto) {
-        ClientImage clientImage = new ClientImage(updatedFileDto.getOriginalFileName(), updatedFileDto.getFilePath());
-        existingClient.removeClientImage();
-        existingClient.updateImage(clientImage);
-    }
 }

--- a/src/main/java/com/map/gaja/client/application/ClientUpdater.java
+++ b/src/main/java/com/map/gaja/client/application/ClientUpdater.java
@@ -2,10 +2,8 @@ package com.map.gaja.client.application;
 
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.domain.model.ClientAddress;
-import com.map.gaja.client.domain.model.ClientImage;
 import com.map.gaja.client.domain.model.ClientLocation;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
-import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 
 import static com.map.gaja.client.application.ClientConvertor.dtoToVo;
 
@@ -17,7 +15,7 @@ public class ClientUpdater {
         ClientAddress updatedAddress = dtoToVo(updateRequest.getAddress());
         ClientLocation updatedLocation = dtoToVo(updateRequest.getLocation());
 
-        existingClient.updateClientField(
+        existingClient.updateWithoutClientImage(
                 updateRequest.getClientName(),
                 updateRequest.getPhoneNumber(),
                 updatedAddress,

--- a/src/main/java/com/map/gaja/client/domain/model/Client.java
+++ b/src/main/java/com/map/gaja/client/domain/model/Client.java
@@ -56,7 +56,7 @@ public class Client extends BaseTimeEntity {
         this.clientImage = clientImage;
     }
 
-    public void updateClientField(String name, String phoneNumber, ClientAddress address, ClientLocation location) {
+    public void updateWithoutClientImage(String name, String phoneNumber, ClientAddress address, ClientLocation location) {
         updateName(name);
         updatePhoneNumber(phoneNumber);
         updateLocation(location, address);

--- a/src/main/java/com/map/gaja/client/domain/model/ClientImage.java
+++ b/src/main/java/com/map/gaja/client/domain/model/ClientImage.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.*;
 import java.util.Objects;
@@ -39,11 +38,11 @@ public class ClientImage extends BaseTimeEntity {
     }
 
     private static String createFilePath(String loginEmail, String originalFilename) {
-        String uuidFileName = createUuidFileName(originalFilename);
+        String uuidFileName = convertRawFileStringToUuidFileString(originalFilename);
         return loginEmail + "/" + uuidFileName;
     }
 
-    private static String createUuidFileName(String originalFilename) {
+    private static String convertRawFileStringToUuidFileString(String originalFilename) {
         String uuid = UUID.randomUUID().toString();
         String ext = extractExtension(originalFilename);
         return uuid + "." + ext;

--- a/src/main/java/com/map/gaja/client/domain/model/ClientImage.java
+++ b/src/main/java/com/map/gaja/client/domain/model/ClientImage.java
@@ -29,10 +29,9 @@ public class ClientImage extends BaseTimeEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
-    public static ClientImage create(String loginEmail, MultipartFile file) {
-        String originalFilename = file.getOriginalFilename();
-        String savedPath = createFilePath(loginEmail, originalFilename);
-        return new ClientImage(originalFilename, savedPath);
+    public static ClientImage create(String loginEmail, String originalFileName) {
+        String savedPath = createFilePath(loginEmail, originalFileName);
+        return new ClientImage(originalFileName, savedPath);
     }
 
     private static String createFilePath(String loginEmail, String originalFilename) {

--- a/src/main/java/com/map/gaja/client/domain/model/ClientImage.java
+++ b/src/main/java/com/map/gaja/client/domain/model/ClientImage.java
@@ -9,6 +9,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.*;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -30,6 +31,9 @@ public class ClientImage extends BaseTimeEntity {
     private Boolean isDeleted;
 
     public static ClientImage create(String loginEmail, String originalFileName) {
+        Objects.requireNonNull(loginEmail);
+        Objects.requireNonNull(originalFileName);
+
         String savedPath = createFilePath(loginEmail, originalFileName);
         return new ClientImage(originalFileName, savedPath);
     }

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -162,9 +162,8 @@ public class ClientController implements ClientCommandApiSpecification {
             return new ResponseEntity<>(clientService.saveClient(clientRequest), HttpStatus.CREATED);
         }
 
-        StoredFileDto storedFileDto = fileService.createTemporaryFileDto(loginEmail, clientRequest.getClientImage());
-        ClientOverviewResponse response = clientService.saveClientWithImage(clientRequest, storedFileDto);
-        if (storeImage(clientRequest, storedFileDto)) {
+        ClientOverviewResponse response = clientService.saveClientWithImage(clientRequest, loginEmail);
+        if (storeImage(clientRequest, response.getImage())) {
             return new ResponseEntity<>(response, HttpStatus.CREATED);
         }
 

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -91,9 +91,8 @@ public class ClientController implements ClientCommandApiSpecification {
         // 기본 이미지를 사용하지 않고, 새 이미지 파일을 요청에 실어보냄
         if (!clientRequest.getIsBasicImage() && !isEmptyFile(clientImage)) {
             // 기존 이미지를 제거하고 업데이트된 이미지를 사용한다.
-            StoredFileDto newFileDto = fileService.createTemporaryFileDto(loginEmail, clientRequest.getClientImage()); // 임시 UUID 생성
-            ClientOverviewResponse response = clientService.updateClientWithNewImage(clientId, clientRequest, newFileDto); // 임시 UUID를 path로 저장
-            if (storeImage(clientRequest, newFileDto)) { // 이미지 저장 성공 여부
+            ClientOverviewResponse response = clientService.updateClientWithNewImage(clientId, clientRequest, loginEmail); // 임시 UUID를 path로 저장
+            if (storeImage(clientRequest, response.getImage())) { // 이미지 저장 성공 여부
                 return new ResponseEntity<>(response, HttpStatus.OK);
             }
 

--- a/src/test/java/com/map/gaja/TestEntityCreator.java
+++ b/src/test/java/com/map/gaja/TestEntityCreator.java
@@ -60,8 +60,4 @@ public class TestEntityCreator {
         Group group = createGroup(user, groupName);
         return group;
     }
-
-    public static ClientImage createMockImage(String imageName) {
-        return new ClientImage(imageName, UUID.randomUUID().toString());
-    }
 }

--- a/src/test/java/com/map/gaja/client/application/ClientQueryServiceTest.java
+++ b/src/test/java/com/map/gaja/client/application/ClientQueryServiceTest.java
@@ -59,8 +59,9 @@ class ClientQueryServiceTest {
         when(findClient.getLocation()).thenReturn(new ClientLocation());
         when(findClient.getGroup()).thenReturn(Group.builder().id(groupId).build());
 
-        String savedPath = "testImage";
-        when(findClient.getClientImage()).thenReturn(new ClientImage("testImage", savedPath));
+        String testEmail = "test@example.com";
+        String savedPath = "testImage.png";
+        when(findClient.getClientImage()).thenReturn(ClientImage.create(testEmail, savedPath));
 
         //when
         ClientDetailResponse response = clientQueryService.findClient(searchId);
@@ -68,7 +69,8 @@ class ClientQueryServiceTest {
         //then
         assertThat(response.getClientId()).isEqualTo(searchId);
         assertThat(response.getClientName()).isEqualTo(searchName);
-        assertThat(response.getImage().getFilePath()).isEqualTo(savedPath);
+        assertThat(response.getImage().getFilePath()).isNotEqualTo(savedPath);
+        assertThat(response.getImage().getFilePath()).startsWith(testEmail);
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/domain/model/ClientImageTest.java
+++ b/src/test/java/com/map/gaja/client/domain/model/ClientImageTest.java
@@ -10,7 +10,7 @@ class ClientImageTest {
     @Test
     void aaa() {
         Assertions.assertThrows(InvalidFileException.class, () -> {
-            new ClientImage("aaaa",null);
+            ClientImage.create("aaaa","test");
         });
     }
 

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
@@ -10,6 +10,7 @@ import com.map.gaja.client.application.validator.ClientRequestValidator;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleClientBulkRequest;
 import com.map.gaja.client.presentation.dto.request.simple.SimpleNewClientRequest;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.map.gaja.global.authentication.AuthenticationRepository;
 import com.map.gaja.global.authentication.PrincipalDetails;
@@ -90,6 +91,11 @@ public class ClientPostControllerTest {
         doThrow(InvalidFileException.class).when(fileService).storeFile(any(),any());
         mockRequest.param("isBasicImage", String.valueOf(false));
 
+        ClientOverviewResponse response = new ClientOverviewResponse();
+        StoredFileDto fileDto = new StoredFileDto("test", "test");
+        response.setImage(fileDto);
+        when(clientService.saveClientWithImage(any(),any())).thenReturn(response);
+
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isPartialContent());
         verify(clientService, times(1)).saveClientWithImage(any(), any());
     }
@@ -102,6 +108,11 @@ public class ClientPostControllerTest {
         MockHttpServletRequestBuilder mockRequest = ClientRequestCreator.createPostRequestWithImage(testUrl);
         ClientRequestCreator.setNormalField(mockRequest, request);
         mockRequest.param("isBasicImage", String.valueOf(false));
+
+        ClientOverviewResponse response = new ClientOverviewResponse();
+        StoredFileDto fileDto = new StoredFileDto("test", "test");
+        response.setImage(fileDto);
+        when(clientService.saveClientWithImage(any(),any())).thenReturn(response);
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isCreated());
         verify(clientService, times(1)).saveClientWithImage(any(), any());
@@ -119,7 +130,6 @@ public class ClientPostControllerTest {
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity());
         verify(clientService, times(1)).saveClientWithImage(any(), any());
-        verify(fileService, times(1)).createTemporaryFileDto(any(),any());
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPutControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPutControllerTest.java
@@ -9,6 +9,7 @@ import com.map.gaja.client.domain.exception.InvalidFileException;
 import com.map.gaja.client.infrastructure.s3.S3FileService;
 import com.map.gaja.client.application.validator.ClientRequestValidator;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
+import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
 import com.map.gaja.global.authentication.AuthenticationRepository;
 import com.map.gaja.group.application.GroupAccessVerifyService;
@@ -74,6 +75,12 @@ public class ClientPutControllerTest {
         MockHttpServletRequestBuilder mockRequest = ClientRequestCreator.createPutRequestWithImage(testUri, groupId, clientId);
         ClientRequestCreator.setNormalField(mockRequest, request);
         mockRequest.param("isBasicImage", String.valueOf(false));
+
+        ClientOverviewResponse response = new ClientOverviewResponse();
+        StoredFileDto fileDto = new StoredFileDto("test", "test");
+        response.setImage(fileDto);
+        when(clientService.updateClientWithNewImage(any(),any(),any())).thenReturn(response);
+
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isOk());
         verify(clientService, times(1)).updateClientWithNewImage(any(), any(), any());
     }
@@ -86,6 +93,11 @@ public class ClientPutControllerTest {
         ClientRequestCreator.setNormalField(mockRequest, request);
         doThrow(InvalidFileException.class).when(fileService).storeFile(any(),any());
         mockRequest.param("isBasicImage", String.valueOf(false));
+
+        ClientOverviewResponse response = new ClientOverviewResponse();
+        StoredFileDto fileDto = new StoredFileDto("test", "test");
+        response.setImage(fileDto);
+        when(clientService.updateClientWithNewImage(any(),any(),any())).thenReturn(response);
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isPartialContent());
         verify(clientService, times(1)).updateClientWithNewImage(any(), any(), any());
@@ -102,7 +114,6 @@ public class ClientPutControllerTest {
 
         mvc.perform(mockRequest).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity());
         verify(clientService, times(1)).updateClientWithNewImage(any(), any(), any());
-        verify(fileService, times(1)).createTemporaryFileDto(any(), any());
     }
 
     @Test


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #418 

<!--
 전달할 내용
-->
## comment
- 첫 커밋과 마지막 2개 커밋만 확인하면 된다.
나머지는 전부 첫 커밋으로 인한 코드 수정임
- requireNonNull로 NPE 발생할 수 있는데 앞단에서 Null은 걸러줄거니까 명시적으로 놓는다.
- 이런식으로 만드는게 맞지?
```
1. application 계층의 Service에서 create 호출해서 ClientImage 만듦.
2. Client 생성자 또는 메소드에 만든 ClientImage 넘김.
```

<!--
 참고한 사이트
-->
## References
- 