### PR TITLE
feat: User-Client 1:N 단방향 관계 추가

### DIFF
--- a/src/main/java/com/map/gaja/client/application/ClientConvertor.java
+++ b/src/main/java/com/map/gaja/client/application/ClientConvertor.java
@@ -16,6 +16,7 @@ import com.map.gaja.client.presentation.dto.request.subdto.LocationDto;
 import com.map.gaja.client.presentation.dto.response.ClientListResponse;
 import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.client.presentation.dto.subdto.StoredFileDto;
+import com.map.gaja.user.domain.model.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,11 +67,11 @@ public class ClientConvertor {
 
     protected static List<Client> dtoToEntity(NewClientBulkRequest request) {
         List<Client> clients = new ArrayList<>();
-        request.getClients().forEach(client -> clients.add(dtoToEntity(client, null)));
+        request.getClients().forEach(client -> clients.add(dtoToEntity(client, null, null)));
         return clients;
     }
 
-    protected static Client dtoToEntity(NewClientRequest request, Group group) {
+    protected static Client dtoToEntity(NewClientRequest request, Group group, User user) {
         AddressDto address = request.getAddress();
         LocationDto location = request.getLocation();
         return new Client(
@@ -78,19 +79,21 @@ public class ClientConvertor {
                 request.getPhoneNumber(),
                 dtoToVo(address),
                 dtoToVo(location),
-                group
+                group,
+                user
             );
     }
 
-    protected static Client dtoToEntity(SimpleNewClientRequest request, Group group) {
+    protected static Client dtoToEntity(SimpleNewClientRequest request, Group group, User user) {
         return new Client(
                 request.getClientName(),
                 request.getPhoneNumber(),
-                group
+                group,
+                user
         );
     }
 
-    protected static Client dtoToEntity(ParsedClientDto clientData, Group group) {
+    protected static Client dtoToEntity(ParsedClientDto clientData, Group group, User user) {
         ClientAddress address = new ClientAddress(clientData.getAddress(), clientData.getAddressDetail());
         ClientLocation location = dtoToVo(clientData.getLocation());
         return new Client(
@@ -98,7 +101,8 @@ public class ClientConvertor {
                 clientData.getPhoneNumber(),
                 address,
                 location,
-                group
+                group,
+                user
         );
     }
 

--- a/src/main/java/com/map/gaja/client/domain/model/Client.java
+++ b/src/main/java/com/map/gaja/client/domain/model/Client.java
@@ -2,6 +2,7 @@ package com.map.gaja.client.domain.model;
 
 import com.map.gaja.group.domain.model.Group;
 import com.map.gaja.global.auditing.entity.BaseTimeEntity;
+import com.map.gaja.user.domain.model.User;
 import lombok.*;
 
 import javax.persistence.*;
@@ -34,26 +35,33 @@ public class Client extends BaseTimeEntity {
     @JoinColumn(name = "client_image_id")
     private ClientImage clientImage;
 
-    public Client(String name, String phoneNumber, Group group) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public Client(String name, String phoneNumber, Group group, User user) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         updateGroup(group);
+        this.user = user;
     }
 
-    public Client(String name, String phoneNumber, ClientAddress address, ClientLocation location, Group group) {
+    public Client(String name, String phoneNumber, ClientAddress address, ClientLocation location, Group group, User user) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         updateLocation(location, address);
         updateGroup(group);
         this.clientImage = null;
+        this.user = user;
     }
 
-    public Client(String name, String phoneNumber, ClientAddress address, ClientLocation location, Group group, ClientImage clientImage) {
+    public Client(String name, String phoneNumber, ClientAddress address, ClientLocation location, Group group, ClientImage clientImage, User user) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         updateLocation(location, address);
         updateGroup(group);
         this.clientImage = clientImage;
+        this.user = user;
     }
 
     public void updateWithoutClientImage(String name, String phoneNumber, ClientAddress address, ClientLocation location) {

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientBulkRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientBulkRepository.java
@@ -26,8 +26,8 @@ public class ClientBulkRepository {
      */
     public void saveClientWithGroup(Group group, List<Client> newClient) {
         final String insertSQL = "INSERT INTO " +
-                "client (name, phone_number, address, detail, location, group_id, created_at, updated_at) " +
-                "VALUES(?, ?, ?, ?, ST_GeomFromText(?, 4326), ?, NOW(), NOW())";
+                "client (name, phone_number, address, detail, location, group_id, created_at, updated_at, user_id) " +
+                "VALUES(?, ?, ?, ?, ST_GeomFromText(?, 4326), ?, NOW(), NOW(), ?)";
 
 
         template.batchUpdate(insertSQL, new BatchPreparedStatementSetter() {
@@ -41,6 +41,7 @@ public class ClientBulkRepository {
                 setStringOrSetNull(ps, 5, client.getLocation() == null || client.getLocation().getLocation() == null ? null
                         : "POINT(" + client.getLocation().getLocation().getX() +" " + client.getLocation().getLocation().getY()+")");
                 ps.setLong(6, group.getId());
+                ps.setLong(7, client.getUser().getId());
             }
 
             private void setStringOrSetNull(PreparedStatement ps, int index, String value) throws SQLException {

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
@@ -54,4 +54,8 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
             "WHERE c.id = :clientId AND g.isDeleted = false")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Client> findClientWithGroupForUpdate(long clientId);
+
+    @Query("SELECT c FROM Client c " +
+            "WHERE c.id=:clientId AND c.user=:userId")
+    Optional<Client> findByIdAndUser(Long clientId, Long userId);
 }

--- a/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/api/ClientController.java
@@ -135,7 +135,7 @@ public class ClientController implements ClientCommandApiSpecification {
     ) {
         // 단순한 Client 정보 등록
         groupAccessVerifyService.verifyGroupAccess(clientBulkRequest.getGroupId(), loginEmail);
-        List<Long> response = clientService.saveSimpleClientList(clientBulkRequest);
+        List<Long> response = clientService.saveSimpleClientList(clientBulkRequest, loginEmail);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
@@ -158,7 +158,7 @@ public class ClientController implements ClientCommandApiSpecification {
 
         if (isEmptyFile(clientRequest.getClientImage())) {
             // 이미지를 등록하지 않음.
-            return new ResponseEntity<>(clientService.saveClient(clientRequest), HttpStatus.CREATED);
+            return new ResponseEntity<>(clientService.saveClient(clientRequest, loginEmail), HttpStatus.CREATED);
         }
 
         ClientOverviewResponse response = clientService.saveClientWithImage(clientRequest, loginEmail);

--- a/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
+++ b/src/main/java/com/map/gaja/client/presentation/web/WebClientController.java
@@ -110,7 +110,7 @@ public class WebClientController {
         Mono<Void> mono = geocoder.convertToCoordinatesAsync(clientExcelData);
 
         return mono.doOnSuccess(s -> { //비동기 작업 모두 성공할 경우 후처리
-                    clientService.saveClientExcelData(groupId, clientExcelData, authority);
+                    clientService.saveClientExcelData(groupId, clientExcelData, authority, loginEmail);
                 })
                 .thenReturn(clientExcelData.size()); //저장 성공 수
     }

--- a/src/test/java/com/map/gaja/TestEntityCreator.java
+++ b/src/test/java/com/map/gaja/TestEntityCreator.java
@@ -10,7 +10,7 @@ import com.map.gaja.user.domain.model.User;
 import java.util.UUID;
 
 public class TestEntityCreator {
-    public static Client createClient(int sigIdx, Group group) {
+    public static Client createClient(int sigIdx, Group group, User user) {
         String sig = sigIdx+""+sigIdx;
         double pointSig = 0.003;
 
@@ -18,15 +18,17 @@ public class TestEntityCreator {
         String phoneNumber = "010-1111-" + sig;
         ClientAddress address = new ClientAddress("address " + sig, "detail " + sig);
         ClientLocation location = new ClientLocation(35d + pointSig * sigIdx, 125.0d + pointSig * sigIdx);
-        return new Client(name, phoneNumber, address, location, group);
+        return new Client(name, phoneNumber, address, location, group, user);
     }
 
-    public static Client createClientWithImage(String clientName, Group existingGroup, ClientImage existingImage) {
+    public static Client createClientWithImage(String clientName, Group existingGroup, ClientImage existingImage, User user) {
         return new Client(
                 clientName, null,
                 new ClientAddress("Test Main Address", "Test Detail Address"),
                 new ClientLocation(35d, 125d),
-                existingGroup, existingImage
+                existingGroup,
+                existingImage,
+                user
         );
     }
 

--- a/src/test/java/com/map/gaja/client/application/ClientBulkInsertTest.java
+++ b/src/test/java/com/map/gaja/client/application/ClientBulkInsertTest.java
@@ -49,7 +49,7 @@ public class ClientBulkInsertTest {
 
         /*========================================*/
         for (int i = 0; i < loop; i++) {
-            Client client = TestEntityCreator.createClient(i, group);
+            Client client = TestEntityCreator.createClient(i, group, group.getUser());
             clientRepository.save(client);
         }
         /*========================================*/
@@ -68,7 +68,7 @@ public class ClientBulkInsertTest {
         /*========================================*/
         List<Client> list = new ArrayList<>();
         for (int i = 0; i < loop; i++) {
-            Client client = TestEntityCreator.createClient(i, group);
+            Client client = TestEntityCreator.createClient(i, group, group.getUser());
             list.add(client);
         }
         clientRepository.saveAll(list);
@@ -88,7 +88,7 @@ public class ClientBulkInsertTest {
         /*========================================*/
         List<Client> list = new ArrayList<>();
         for (int i = 0; i < loop; i++) {
-            Client client = TestEntityCreator.createClient(i, group);
+            Client client = TestEntityCreator.createClient(i, group, group.getUser());
             list.add(client);
         }
         clientBulkRepository.saveClientWithGroup(group, list);

--- a/src/test/java/com/map/gaja/client/application/ClientQueryServiceTest.java
+++ b/src/test/java/com/map/gaja/client/application/ClientQueryServiceTest.java
@@ -99,8 +99,8 @@ class ClientQueryServiceTest {
 
         List<Client> clientList = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
-            clientList.add(TestEntityCreator.createClient(i, testGroup1));
-            clientList.add(TestEntityCreator.createClient(i, testGroup2));
+            clientList.add(TestEntityCreator.createClient(i, testGroup1, testUser));
+            clientList.add(TestEntityCreator.createClient(i, testGroup2, testUser));
         }
         List<ClientOverviewResponse> testList = ClientConvertor.entityToDto(clientList).getClients();
 
@@ -131,8 +131,8 @@ class ClientQueryServiceTest {
         List<Long> groupIdList = List.of(groupId1, groupId2);
         List<Client> clientList = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
-            clientList.add(TestEntityCreator.createClient(i, testGroup1));
-            clientList.add(TestEntityCreator.createClient(i, testGroup2));
+            clientList.add(TestEntityCreator.createClient(i, testGroup1, testUser));
+            clientList.add(TestEntityCreator.createClient(i, testGroup2, testUser));
         }
         List<ClientOverviewResponse> testList = ClientConvertor.entityToDto(clientList).getClients();
 

--- a/src/test/java/com/map/gaja/client/application/ClientServiceTest.java
+++ b/src/test/java/com/map/gaja/client/application/ClientServiceTest.java
@@ -19,6 +19,7 @@ import com.map.gaja.client.infrastructure.repository.ClientRepository;
 import com.map.gaja.client.presentation.dto.request.NewClientRequest;
 import com.map.gaja.user.domain.model.Authority;
 import com.map.gaja.user.domain.model.User;
+import com.map.gaja.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,8 @@ class ClientServiceTest {
     private GroupRepository groupRepository;
     @Mock
     private ClientQueryRepository clientQueryRepository;
+    @Mock
+    private UserRepository userRepository;
     IncreasingClientService increasingClientService = new IncreasingClientService();
     @Mock
     AuthenticationRepository securityUserGetter;
@@ -76,14 +79,15 @@ class ClientServiceTest {
                 groupRepository,
                 clientQueryRepository,
                 increasingClientService,
-                securityUserGetter
+                securityUserGetter,
+                userRepository
         );
 
         user = TestEntityCreator.createUser(email);
         existingGroup = TestEntityCreator.createGroup(user, groupId, "Test Group1", 1);
         changedGroup = TestEntityCreator.createGroup(user, groupId, "Test Group2", 0);
         clientImage = ClientImage.create(email, "Image.png");
-        existingClient = TestEntityCreator.createClientWithImage(existingName, existingGroup, clientImage);
+        existingClient = TestEntityCreator.createClientWithImage(existingName, existingGroup, clientImage, user);
     }
 
     @Test
@@ -102,7 +106,7 @@ class ClientServiceTest {
         });
 
         // when
-        ClientOverviewResponse result = clientService.saveClient(changedRequest);
+        ClientOverviewResponse result = clientService.saveClient(changedRequest, user.getEmail());
 
         // then
         assertThat(result.getClientId()).isEqualTo(clientId);
@@ -273,7 +277,7 @@ class ClientServiceTest {
         });
 
         SimpleClientBulkRequest bulkRequest = new SimpleClientBulkRequest(existingGroup.getId(), clients);
-        clientService.saveSimpleClientList(bulkRequest);
+        clientService.saveSimpleClientList(bulkRequest, user.getEmail());
 
         assertThat(existingGroup.getClientCount()).isEqualTo(beforeClientCount + clients.size());
     }
@@ -287,7 +291,7 @@ class ClientServiceTest {
                 .thenReturn(Optional.ofNullable(existingGroup));
 
 
-        clientService.saveClientExcelData(existingGroup.getId(), excelData, List.of(Authority.FREE));
+        clientService.saveClientExcelData(existingGroup.getId(), excelData, List.of(Authority.FREE), user.getEmail());
 
         assertThat(existingGroup.getClientCount()).isEqualTo(beforeClientCount + excelData.size());
     }

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientBulkNativeRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientBulkNativeRepositoryTest.java
@@ -40,7 +40,7 @@ class ClientBulkNativeRepositoryTest {
 
         clientList = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Client client = TestEntityCreator.createClient(i, group);
+            Client client = TestEntityCreator.createClient(i, group, user);
             clientList.add(client);
         }
     }

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientNativeRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientNativeRepositoryTest.java
@@ -55,12 +55,12 @@ class ClientNativeRepositoryTest {
         em.persist(group2);
 
         for (int j = 0; j < 5; j++) {
-            Client client = new Client("name", "010-1234-1234", group);
+            Client client = new Client("name", "010-1234-1234", group, user);
             em.persist(client);
         }
 
         for (int j = 0; j < 5; j++) {
-            Client client = new Client("name", "010-1234-1234", group2);
+            Client client = new Client("name", "010-1234-1234", group2, user2);
             em.persist(client);
         }
 

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
@@ -51,13 +51,13 @@ class ClientQueryNativeRepositoryTest {
 
         group1ClientList = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Client client = TestEntityCreator.createClient(i, group1);
+            Client client = TestEntityCreator.createClient(i, group1, user);
             group1ClientList.add(client);
         }
 
         group2ClientList = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            Client client = TestEntityCreator.createClient(i, group2);
+            Client client = TestEntityCreator.createClient(i, group2, user);
             group2ClientList.add(client);
         }
         clientRepository.saveAll(group1ClientList);

--- a/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/api/ClientPostControllerTest.java
@@ -151,7 +151,7 @@ public class ClientPostControllerTest {
                 .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(1L, "test@gmail.com", "FREE")));
 
         mvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isCreated());
-        verify(clientService, times(1)).saveSimpleClientList(request);
+        verify(clientService, times(1)).saveSimpleClientList(request, "test@gmail.com");
     }
 
 }

--- a/src/test/java/com/map/gaja/client/presentation/web/WebClientControllerTest.java
+++ b/src/test/java/com/map/gaja/client/presentation/web/WebClientControllerTest.java
@@ -110,7 +110,7 @@ class WebClientControllerTest {
                 .param("groupId", String.valueOf(groupId));
 
         mvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk());
-        verify(clientService, times(1)).saveClientExcelData(groupId, successList, List.of(Authority.FREE));
+        verify(clientService, times(1)).saveClientExcelData(groupId, successList, List.of(Authority.FREE), "test@gmail.com");
     }
 
     @Test


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #428 

<!--
 전달할 내용
-->
## comment
- Client 생성자에 User 추가함
- ClientService에서 Client 생성하는 모든 메소드들에 UserRepository로 User를 조회한다음 Client에 User를 넣어줬음
- ClientTest도 User 넣어서 수정함
- ddl-auto: update로 해서 필드를 추가할지 DB에 직접 필드를 추가할지 정해야 됨 기존 Client 데이터에는 User가 없으므로 DB에 직접 update로 변경해줘야 될 것 같음

<!--
 참고한 사이트
-->
## References
- 