### PR TITLE
메모 기능

### DIFF
--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
@@ -59,6 +59,7 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
      * User가 가진 단일 클라이언트 조회
      */
     @Query("SELECT c FROM Client c " +
+            "JOIN FETCH c.user u " +
             "WHERE c.id=:clientId AND c.user.id=:userId")
     Optional<Client> findByIdAndUser(@Param("clientId") Long clientId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientRepository.java
@@ -55,7 +55,10 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Client> findClientWithGroupForUpdate(long clientId);
 
+    /**
+     * User가 가진 단일 클라이언트 조회
+     */
     @Query("SELECT c FROM Client c " +
-            "WHERE c.id=:clientId AND c.user=:userId")
-    Optional<Client> findByIdAndUser(Long clientId, Long userId);
+            "WHERE c.id=:clientId AND c.user.id=:userId")
+    Optional<Client> findByIdAndUser(@Param("clientId") Long clientId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/map/gaja/global/config/SwaggerConfig.java
+++ b/src/main/java/com/map/gaja/global/config/SwaggerConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
     @Bean
-    public GroupedOpenApi userApi(){
+    public GroupedOpenApi userApi() {
         return GroupedOpenApi.builder()
                 .group("user-api")
                 .pathsToMatch("/api/user/**")
@@ -17,7 +17,7 @@ public class SwaggerConfig {
     }
 
     @Bean
-    public GroupedOpenApi GroupApi(){
+    public GroupedOpenApi GroupApi() {
         return GroupedOpenApi.builder()
                 .group("group-api")
                 .pathsToMatch("/api/group/**")
@@ -26,7 +26,7 @@ public class SwaggerConfig {
     }
 
     @Bean
-    public GroupedOpenApi clientApi(){
+    public GroupedOpenApi clientApi() {
         return GroupedOpenApi.builder()
                 .group("client-api")
                 .pathsToMatch("/api/**/clients/**")
@@ -34,11 +34,19 @@ public class SwaggerConfig {
     }
 
     @Bean
-    public OpenAPI openApi(){
+    public GroupedOpenApi memoApi() {
+        return GroupedOpenApi.builder()
+                .group("memo-api")
+                .pathsToMatch("/api/memo/**")
+                .build();
+    }
+
+    @Bean
+    public OpenAPI openApi() {
         return new OpenAPI()
                 .info(new Info()
                         .title("GaJaMap API")
                         .description("API 명세서")
-                        .version("0.0.1"));
+                        .version("0.0.2"));
     }
 }

--- a/src/main/java/com/map/gaja/global/config/WebConfig.java
+++ b/src/main/java/com/map/gaja/global/config/WebConfig.java
@@ -1,31 +1,18 @@
 package com.map.gaja.global.config;
 
-import com.map.gaja.global.filter.EmailCheckFilter;
-import com.map.gaja.global.resolver.LoginEmailResolver;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
+import com.map.gaja.global.resolver.LimitedPageableArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import javax.servlet.Filter;
 import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    /*
-        @Override
-        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginEmailResolver());
-        }
-     */
 
-//    @Bean
-    public FilterRegistrationBean<Filter> testFilter() {
-        FilterRegistrationBean<Filter> filterBean = new FilterRegistrationBean<>();
-        filterBean.setFilter(new EmailCheckFilter());
-//        filterBean.setOrder(1);
-        filterBean.addUrlPatterns("/api/*"); // /api 전역으로 활성화
-        return filterBean;
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LimitedPageableArgumentResolver());
     }
+
 }

--- a/src/main/java/com/map/gaja/global/resolver/LimitedPageableArgumentResolver.java
+++ b/src/main/java/com/map/gaja/global/resolver/LimitedPageableArgumentResolver.java
@@ -1,0 +1,22 @@
+package com.map.gaja.global.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LimitedPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+    @Override
+    public Pageable resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String pageSize = webRequest.getParameter(getParameterNameToUse(getSizeParameterName(), methodParameter));
+
+        if (pageSize != null) {
+            throw new IllegalArgumentException("페이지 사이즈 크기를 지정할 수 없습니다.");
+        }
+
+        return super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+    }
+}

--- a/src/main/java/com/map/gaja/memo/application/MemoService.java
+++ b/src/main/java/com/map/gaja/memo/application/MemoService.java
@@ -3,7 +3,6 @@ package com.map.gaja.memo.application;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.infrastructure.repository.ClientRepository;
-import com.map.gaja.memo.domain.exception.MemoNotFoundException;
 
 import com.map.gaja.memo.domain.model.Memo;
 import com.map.gaja.memo.domain.model.MemoType;
@@ -24,26 +23,18 @@ public class MemoService {
 
     @Transactional
     public Long create(Long userId, Long clientId, MemoCreateRequest request) {
-        Client client = findClient(userId, clientId);
+        Client client = clientRepository.findByIdAndUser(clientId, userId)
+                .orElseThrow(ClientNotFoundException::new);
 
-        Memo memo = new Memo(request.getMessage(), MemoType.from(request.getMemoType()), client);
+        Memo memo = new Memo(request.getMessage(), MemoType.from(request.getMemoType()), client, client.getUser());
         memoRepository.save(memo);
 
         return memo.getId();
     }
 
     @Transactional
-    public void delete(Long userId, Long clientId, Long memoId) {
-        findClient(userId, clientId);
-
-        Memo memo = memoRepository.findByIdAndClient(memoId, clientId)
-                .orElseThrow(MemoNotFoundException::new);
-        memoRepository.delete(memo);
-    }
-
-    private Client findClient(Long userId, Long clientId) {
-        return clientRepository.findByIdAndUser(clientId, userId)
-                .orElseThrow(ClientNotFoundException::new);
+    public void delete(Long userId, Long memoId) {
+        memoRepository.deleteByIdAndUser(memoId, userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/map/gaja/memo/application/MemoService.java
+++ b/src/main/java/com/map/gaja/memo/application/MemoService.java
@@ -1,0 +1,31 @@
+package com.map.gaja.memo.application;
+
+import com.map.gaja.client.domain.exception.ClientNotFoundException;
+import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.client.infrastructure.repository.ClientRepository;
+import com.map.gaja.memo.domain.model.Memo;
+import com.map.gaja.memo.domain.model.MemoType;
+import com.map.gaja.memo.infrastructure.MemoRepository;
+import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+    private final MemoRepository memoRepository;
+    private final ClientRepository clientRepository;
+
+    @Transactional
+    public void create(Long userId, Long clientId, MemoCreateRequest request) {
+        Client client = clientRepository.findByIdAndUser(clientId, userId)
+                .orElseThrow(() -> {
+                    throw new ClientNotFoundException();
+                });
+
+        memoRepository.save(
+                new Memo(request.getMessage(), MemoType.from(request.getMemoType()), client)
+        );
+    }
+}

--- a/src/main/java/com/map/gaja/memo/application/MemoService.java
+++ b/src/main/java/com/map/gaja/memo/application/MemoService.java
@@ -3,6 +3,8 @@ package com.map.gaja.memo.application;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.infrastructure.repository.ClientRepository;
+import com.map.gaja.memo.domain.exception.MemoNotFoundException;
+
 import com.map.gaja.memo.domain.model.Memo;
 import com.map.gaja.memo.domain.model.MemoType;
 import com.map.gaja.memo.infrastructure.MemoRepository;
@@ -19,14 +21,25 @@ public class MemoService {
 
     @Transactional
     public Long create(Long userId, Long clientId, MemoCreateRequest request) {
-        Client client = clientRepository.findByIdAndUser(clientId, userId)
-                .orElseThrow(() -> {
-                    throw new ClientNotFoundException();
-                });
+        Client client = findClient(userId, clientId);
 
         Memo memo = new Memo(request.getMessage(), MemoType.from(request.getMemoType()), client);
         memoRepository.save(memo);
 
         return memo.getId();
+    }
+
+    @Transactional
+    public void delete(Long userId, Long clientId, Long memoId) {
+        findClient(userId, clientId);
+
+        Memo memo = memoRepository.findByIdAndClient(memoId, clientId)
+                .orElseThrow(MemoNotFoundException::new);
+        memoRepository.delete(memo);
+    }
+
+    private Client findClient(Long userId, Long clientId) {
+        return clientRepository.findByIdAndUser(clientId, userId)
+                .orElseThrow(ClientNotFoundException::new);
     }
 }

--- a/src/main/java/com/map/gaja/memo/application/MemoService.java
+++ b/src/main/java/com/map/gaja/memo/application/MemoService.java
@@ -18,14 +18,15 @@ public class MemoService {
     private final ClientRepository clientRepository;
 
     @Transactional
-    public void create(Long userId, Long clientId, MemoCreateRequest request) {
+    public Long create(Long userId, Long clientId, MemoCreateRequest request) {
         Client client = clientRepository.findByIdAndUser(clientId, userId)
                 .orElseThrow(() -> {
                     throw new ClientNotFoundException();
                 });
 
-        memoRepository.save(
-                new Memo(request.getMessage(), MemoType.from(request.getMemoType()), client)
-        );
+        Memo memo = new Memo(request.getMessage(), MemoType.from(request.getMemoType()), client);
+        memoRepository.save(memo);
+
+        return memo.getId();
     }
 }

--- a/src/main/java/com/map/gaja/memo/application/MemoService.java
+++ b/src/main/java/com/map/gaja/memo/application/MemoService.java
@@ -9,7 +9,10 @@ import com.map.gaja.memo.domain.model.Memo;
 import com.map.gaja.memo.domain.model.MemoType;
 import com.map.gaja.memo.infrastructure.MemoRepository;
 import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import com.map.gaja.memo.presentation.dto.response.MemoPageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,5 +44,12 @@ public class MemoService {
     private Client findClient(Long userId, Long clientId) {
         return clientRepository.findByIdAndUser(clientId, userId)
                 .orElseThrow(ClientNotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public MemoPageResponse findPageByClientId(Long userId, Long clientId, Pageable pageable) {
+        Slice<Memo> memos = memoRepository.findPageByClientId(clientId, userId, pageable);
+
+        return MemoPageResponse.from(memos);
     }
 }

--- a/src/main/java/com/map/gaja/memo/domain/exception/MemoNotFoundException.java
+++ b/src/main/java/com/map/gaja/memo/domain/exception/MemoNotFoundException.java
@@ -1,0 +1,13 @@
+package com.map.gaja.memo.domain.exception;
+
+import com.map.gaja.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class MemoNotFoundException extends BusinessException {
+    private static final String MESSAGE = "존재하지 않는 메모입니다.";
+
+    public MemoNotFoundException() {
+        super(HttpStatus.NOT_FOUND, MESSAGE);
+    }
+}
+

--- a/src/main/java/com/map/gaja/memo/domain/exception/MemoTypeNotFoundException.java
+++ b/src/main/java/com/map/gaja/memo/domain/exception/MemoTypeNotFoundException.java
@@ -1,0 +1,12 @@
+package com.map.gaja.memo.domain.exception;
+
+import com.map.gaja.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class MemoTypeNotFoundException extends BusinessException {
+    private static final String MESSAGE = "존재하지 않는 메모 타입입니다.";
+
+    public MemoTypeNotFoundException() {
+        super(HttpStatus.NOT_FOUND, MESSAGE);
+    }
+}

--- a/src/main/java/com/map/gaja/memo/domain/model/Memo.java
+++ b/src/main/java/com/map/gaja/memo/domain/model/Memo.java
@@ -1,6 +1,7 @@
 package com.map.gaja.memo.domain.model;
 
 import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.user.domain.model.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,18 +36,24 @@ public class Memo {
     @JoinColumn(name = "client_id")
     private Client client;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @Builder
-    private Memo(Long id, String message, MemoType memoType, LocalDateTime createdAt, Client client) {
+    private Memo(Long id, String message, MemoType memoType, LocalDateTime createdAt, Client client, User user) {
         this.id = id;
         this.message = message;
         this.memoType = memoType;
         this.createdAt = createdAt;
         this.client = client;
+        this.user = user;
     }
 
-    public Memo(String message, MemoType memoType, Client client) {
+    public Memo(String message, MemoType memoType, Client client, User user) {
         this.message = message;
         this.memoType = memoType;
         this.client = client;
+        this.user = user;
     }
 }

--- a/src/main/java/com/map/gaja/memo/domain/model/Memo.java
+++ b/src/main/java/com/map/gaja/memo/domain/model/Memo.java
@@ -1,0 +1,52 @@
+package com.map.gaja.memo.domain.model;
+
+import com.map.gaja.client.domain.model.Client;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memo_id")
+    private Long id;
+
+    @Column(length = 100)
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    private MemoType memoType;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "client_id")
+    private Client client;
+
+    @Builder
+    private Memo(Long id, String message, MemoType memoType, LocalDateTime createdAt, Client client) {
+        this.id = id;
+        this.message = message;
+        this.memoType = memoType;
+        this.createdAt = createdAt;
+        this.client = client;
+    }
+
+    public Memo(String message, MemoType memoType, Client client) {
+        this.message = message;
+        this.memoType = memoType;
+        this.client = client;
+    }
+}

--- a/src/main/java/com/map/gaja/memo/domain/model/Memo.java
+++ b/src/main/java/com/map/gaja/memo/domain/model/Memo.java
@@ -31,7 +31,7 @@ public class Memo {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id")
     private Client client;
 

--- a/src/main/java/com/map/gaja/memo/domain/model/MemoType.java
+++ b/src/main/java/com/map/gaja/memo/domain/model/MemoType.java
@@ -1,0 +1,16 @@
+package com.map.gaja.memo.domain.model;
+
+import com.map.gaja.memo.domain.exception.MemoTypeNotFoundException;
+
+import java.util.Arrays;
+
+public enum MemoType {
+    CALL, NAVIGATION, MESSAGE;
+
+    public static MemoType from(String type) {
+        return Arrays.stream(values())
+                .filter(memo -> memo.name().equals(type))
+                .findFirst()
+                .orElseThrow(MemoTypeNotFoundException::new);
+    }
+}

--- a/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
+++ b/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
@@ -1,0 +1,7 @@
+package com.map.gaja.memo.infrastructure;
+
+import com.map.gaja.memo.domain.model.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+}

--- a/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
+++ b/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
@@ -1,6 +1,8 @@
 package com.map.gaja.memo.infrastructure;
 
 import com.map.gaja.memo.domain.model.Memo;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +13,10 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     @Query("SELECT m FROM Memo m " +
             "WHERE m.id=:memoId AND m.client.id=:clientId")
     Optional<Memo> findByIdAndClient(@Param("memoId") Long memoId, @Param("clientId") Long clientId);
+
+    @Query("SELECT m FROM Memo m " +
+            "JOIN m.client c " +
+            "JOIN c.user u " +
+            "WHERE c.id = :clientId AND u.id = :userId")
+    Slice<Memo> findPageByClientId(@Param("clientId") Long clientId, @Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
+++ b/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
@@ -2,6 +2,13 @@ package com.map.gaja.memo.infrastructure;
 
 import com.map.gaja.memo.domain.model.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
+    @Query("SELECT m FROM Memo m " +
+            "WHERE m.id=:memoId AND m.client.id=:clientId")
+    Optional<Memo> findByIdAndClient(@Param("memoId") Long memoId, @Param("clientId") Long clientId);
 }

--- a/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
+++ b/src/main/java/com/map/gaja/memo/infrastructure/MemoRepository.java
@@ -4,6 +4,7 @@ import com.map.gaja.memo.domain.model.Memo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,8 +16,11 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     Optional<Memo> findByIdAndClient(@Param("memoId") Long memoId, @Param("clientId") Long clientId);
 
     @Query("SELECT m FROM Memo m " +
-            "JOIN m.client c " +
-            "JOIN c.user u " +
-            "WHERE c.id = :clientId AND u.id = :userId")
+            "WHERE m.client.id = :clientId AND m.user.id = :userId")
     Slice<Memo> findPageByClientId(@Param("clientId") Long clientId, @Param("userId") Long userId, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM Memo m " +
+            "WHERE m.id=:memoId AND m.user.id=:userId")
+    void deleteByIdAndUser(@Param("memoId") Long memoId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -16,7 +16,7 @@ import javax.validation.Valid;
 public class MemoController {
     private final MemoService memoService;
 
-    @PostMapping("/client/{clientId}/message")
+    @PostMapping("/client/{clientId}")
     public ResponseEntity<Void> create(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long clientId,

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -1,6 +1,7 @@
 package com.map.gaja.memo.presentation.api;
 
 import com.map.gaja.memo.application.MemoService;
+import com.map.gaja.memo.presentation.api.specification.MemoApiSpecification;
 import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
 import com.map.gaja.memo.presentation.dto.response.MemoPageResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ import javax.validation.Valid;
 @RestController
 @RequestMapping("/api/memo")
 @RequiredArgsConstructor
-public class MemoController {
+public class MemoController implements MemoApiSpecification {
     private final MemoService memoService;
 
     @PostMapping("/client/{clientId}")
@@ -40,7 +41,7 @@ public class MemoController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @GetMapping("{memoId}/client/{clientId}")
+    @GetMapping("/client/{clientId}")
     public ResponseEntity<MemoPageResponse> read(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long clientId,

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -31,13 +31,12 @@ public class MemoController implements MemoApiSpecification {
         return new ResponseEntity<>(memoId, HttpStatus.CREATED);
     }
 
-    @DeleteMapping("{memoId}/client/{clientId}")
+    @DeleteMapping("{memoId}")
     public ResponseEntity<Void> delete(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @PathVariable Long memoId,
-            @PathVariable Long clientId
+            @PathVariable Long memoId
     ) {
-        memoService.delete(userId, clientId, memoId);
+        memoService.delete(userId, memoId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -17,12 +17,13 @@ public class MemoController {
     private final MemoService memoService;
 
     @PostMapping("/client/{clientId}")
-    public ResponseEntity<Void> create(
+    public ResponseEntity<Long> create(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long clientId,
             @Valid @RequestBody MemoCreateRequest memoCreateRequest
     ) {
-        memoService.create(userId, clientId, memoCreateRequest);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        Long memoId = memoService.create(userId, clientId, memoCreateRequest);
+        return new ResponseEntity<>(memoId, HttpStatus.CREATED);
     }
+
 }

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -2,7 +2,11 @@ package com.map.gaja.memo.presentation.api;
 
 import com.map.gaja.memo.application.MemoService;
 import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import com.map.gaja.memo.presentation.dto.response.MemoPageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,5 +38,15 @@ public class MemoController {
     ) {
         memoService.delete(userId, clientId, memoId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("{memoId}/client/{clientId}")
+    public ResponseEntity<MemoPageResponse> read(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long clientId,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        MemoPageResponse response = memoService.findPageByClientId(userId, clientId, pageable);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -1,0 +1,28 @@
+package com.map.gaja.memo.presentation.api;
+
+import com.map.gaja.memo.application.MemoService;
+import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/memo")
+@RequiredArgsConstructor
+public class MemoController {
+    private final MemoService memoService;
+
+    @PostMapping("/client/{clientId}/message")
+    public ResponseEntity<Void> create(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long clientId,
+            @Valid @RequestBody MemoCreateRequest memoCreateRequest
+    ) {
+        memoService.create(userId, clientId, memoCreateRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/MemoController.java
@@ -26,4 +26,13 @@ public class MemoController {
         return new ResponseEntity<>(memoId, HttpStatus.CREATED);
     }
 
+    @DeleteMapping("{memoId}/client/{clientId}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long memoId,
+            @PathVariable Long clientId
+    ) {
+        memoService.delete(userId, clientId, memoId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/map/gaja/memo/presentation/api/specification/MemoApiSpecification.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/specification/MemoApiSpecification.java
@@ -32,14 +32,13 @@ public interface MemoApiSpecification {
     @Operation(summary = "메모 삭제",
             parameters = {
                     @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
-                    @Parameter(name = "memoId", description = "Memo ID"),
-                    @Parameter(name = "clientId", description = "Client ID"),
+                    @Parameter(name = "memoId", description = "Memo ID")
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "성공"),
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 또는 메모입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             })
-    ResponseEntity<Void> delete(@Parameter(hidden = true) Long userId, Long memoId, Long clientId);
+    ResponseEntity<Void> delete(@Parameter(hidden = true) Long userId, Long memoId);
 
     @Operation(summary = "메모 페이징 조회",
             parameters = {

--- a/src/main/java/com/map/gaja/memo/presentation/api/specification/MemoApiSpecification.java
+++ b/src/main/java/com/map/gaja/memo/presentation/api/specification/MemoApiSpecification.java
@@ -1,0 +1,55 @@
+package com.map.gaja.memo.presentation.api.specification;
+
+import com.map.gaja.global.exception.ExceptionDto;
+import com.map.gaja.group.presentation.dto.request.GroupCreateRequest;
+import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import com.map.gaja.memo.presentation.dto.response.MemoPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+public interface MemoApiSpecification {
+    @Operation(summary = "메모 생성",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+                    @Parameter(name = "clientId", description = "Client ID")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "응답 값: 메모 id", content = @Content(schema = @Schema(implementation = Long.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 또는 클라이언트입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+            })
+    ResponseEntity<Long> create(
+            @Schema(hidden = true) Long userId,
+            Long clientId,
+            MemoCreateRequest request
+    );
+
+    @Operation(summary = "메모 삭제",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+                    @Parameter(name = "memoId", description = "Memo ID"),
+                    @Parameter(name = "clientId", description = "Client ID"),
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공"),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 또는 메모입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+            })
+    ResponseEntity<Void> delete(@Parameter(hidden = true) Long userId, Long memoId, Long clientId);
+
+    @Operation(summary = "메모 페이징 조회",
+            parameters = {
+                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+                    @Parameter(name = "clientId", description = "Client ID"),
+                    @Parameter(name = "page", description = "페이지 번호 처음은 0번 페이지")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공"),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원 또는 클라이언트입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
+            })
+    ResponseEntity<MemoPageResponse> read(@Parameter(hidden = true) Long userId, Long clientId, Pageable pageable);
+}

--- a/src/main/java/com/map/gaja/memo/presentation/dto/request/MemoCreateRequest.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/request/MemoCreateRequest.java
@@ -1,0 +1,29 @@
+package com.map.gaja.memo.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemoCreateRequest {
+    @Schema(description = "메모 메시지")
+    @NotNull(message = "메세지를 입력해 주세요.")
+    @Size(max = 100, message = "메시지는 100자 이하로 입력해 주세요.")
+    private String message;
+
+    @Schema(description = "메모 타입은 영어로 CALL(전화), NAVIGATION(내비), MESSAGE(메시지)")
+    @NotNull(message = "타입을 지정해 주세요.")
+    @Size(max = 15)
+    private String memoType;
+
+
+    public MemoCreateRequest(String message, String memoType) {
+        this.message = message;
+        this.memoType = memoType;
+    }
+}

--- a/src/main/java/com/map/gaja/memo/presentation/dto/request/MemoCreateRequest.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/request/MemoCreateRequest.java
@@ -12,7 +12,6 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemoCreateRequest {
     @Schema(description = "메모 메시지")
-    @NotNull(message = "메세지를 입력해 주세요.")
     @Size(max = 100, message = "메시지는 100자 이하로 입력해 주세요.")
     private String message;
 

--- a/src/main/java/com/map/gaja/memo/presentation/dto/request/MemoCreateRequest.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/request/MemoCreateRequest.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.Size;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemoCreateRequest {
-    @Schema(description = "메모 메시지")
+    @Schema(description = "메모 타입이 MESSAGE이면 메모 메시지 다른 타입은 NULL")
     @Size(max = 100, message = "메시지는 100자 이하로 입력해 주세요.")
     private String message;
 

--- a/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoPageResponse.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoPageResponse.java
@@ -1,6 +1,7 @@
 package com.map.gaja.memo.presentation.dto.response;
 
 import com.map.gaja.memo.domain.model.Memo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemoPageResponse {
+    @Schema(description = "다음 페이지가 있으면 true, 없으면 false")
     private boolean hasNext;
     private List<MemoResponse> memos;
 

--- a/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoPageResponse.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoPageResponse.java
@@ -1,0 +1,31 @@
+package com.map.gaja.memo.presentation.dto.response;
+
+import com.map.gaja.memo.domain.model.Memo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemoPageResponse {
+    private boolean hasNext;
+    private List<MemoResponse> memos;
+
+    private MemoPageResponse(boolean hasNext, List<MemoResponse> memos) {
+        this.hasNext = hasNext;
+        this.memos = memos;
+    }
+
+    public static MemoPageResponse from(Slice<Memo> page) {
+        List<MemoResponse> memos = page.getContent().stream()
+                .map(MemoResponse::from)
+                .collect(Collectors.toList());
+
+        return new MemoPageResponse(page.hasNext(), memos);
+    }
+
+}

--- a/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoResponse.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoResponse.java
@@ -1,6 +1,7 @@
 package com.map.gaja.memo.presentation.dto.response;
 
 import com.map.gaja.memo.domain.model.Memo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,8 +9,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemoResponse {
+    @Schema(description = "메모 아이디")
     private Long memoId;
+
+    @Schema(description = "메모 타입은 영어로 CALL(전화), NAVIGATION(내비), MESSAGE(메시지)")
     private String memoType;
+
+    @Schema(description = "메모 타입이 MESSAGE이면 내용이 있고 다른 타입은 NULL")
     private String message;
 
     private MemoResponse(Long memoId, String memoType, String message) {

--- a/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoResponse.java
+++ b/src/main/java/com/map/gaja/memo/presentation/dto/response/MemoResponse.java
@@ -1,0 +1,24 @@
+package com.map.gaja.memo.presentation.dto.response;
+
+import com.map.gaja.memo.domain.model.Memo;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemoResponse {
+    private Long memoId;
+    private String memoType;
+    private String message;
+
+    private MemoResponse(Long memoId, String memoType, String message) {
+        this.memoId = memoId;
+        this.memoType = memoType;
+        this.message = message;
+    }
+
+    public static MemoResponse from(Memo memo) {
+        return new MemoResponse(memo.getId(), memo.getMemoType().name(), memo.getMessage());
+    }
+}

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientRepositoryTest.java
@@ -32,10 +32,15 @@ class ClientRepositoryTest {
         em.persist(user);
         em.persist(group);
         Client client = clientRepository.save(TestEntityCreator.createClient(0, group, user));
+        em.flush();
+        em.clear();
 
-        // when, then
-        assertThat(clientRepository.findByIdAndUser(client.getId(), user.getId()).get())
-                .isNotNull();
+        // when
+        Client expect = clientRepository.findByIdAndUser(client.getId(), user.getId()).get();
+
+        //then
+        assertThat(expect.getUser().getId())
+                .isEqualTo(user.getId());
     }
 
     @Test

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.map.gaja.client.infrastructure.repository;
+
+import com.map.gaja.TestEntityCreator;
+import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.group.domain.model.Group;
+import com.map.gaja.user.domain.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class ClientRepositoryTest {
+    @Autowired
+    ClientRepository clientRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("User가 가진 Client를 조회한다.")
+    void findByIdAndUserSuccess() {
+        // given
+        User user = TestEntityCreator.createUser("test@gmail.com");
+        Group group = TestEntityCreator.createGroup(user, "group");
+        em.persist(user);
+        em.persist(group);
+        Client client = clientRepository.save(TestEntityCreator.createClient(0, group, user));
+
+        // when, then
+        assertThat(clientRepository.findByIdAndUser(client.getId(), user.getId()).get())
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("User가 가진 Client의 조회 실패한다.")
+    void findByIdAndUserFail() {
+        // given
+        User user = TestEntityCreator.createUser("test@gmail.com");
+        Group group = TestEntityCreator.createGroup(user, "group");
+        em.persist(user);
+        em.persist(group);
+        Client client = clientRepository.save(TestEntityCreator.createClient(0, group, user));
+
+        // when, then
+        assertThat(clientRepository.findByIdAndUser(client.getId() + 1, user.getId()).isEmpty())
+                .isTrue();
+    }
+}

--- a/src/test/java/com/map/gaja/memo/application/MemoServiceTest.java
+++ b/src/test/java/com/map/gaja/memo/application/MemoServiceTest.java
@@ -3,6 +3,9 @@ package com.map.gaja.memo.application;
 import com.map.gaja.client.domain.exception.ClientNotFoundException;
 import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.infrastructure.repository.ClientRepository;
+import com.map.gaja.memo.domain.exception.MemoNotFoundException;
+import com.map.gaja.memo.domain.model.Memo;
+import com.map.gaja.memo.domain.model.MemoType;
 import com.map.gaja.memo.infrastructure.MemoRepository;
 import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +65,41 @@ class MemoServiceTest {
         assertThatThrownBy(() -> memoService.create(userId, clientId, request))
                 .isInstanceOf(ClientNotFoundException.class);
 
+    }
 
+    @Test
+    @DisplayName("메모 삭제에 성공한다.")
+    void deleteSuccess() {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        Long memoId = 1L;
+        given(clientRepository.findByIdAndUser(anyLong(), anyLong()))
+                .willReturn(Optional.of(new Client("a", "a", null, null)));
+        given(memoRepository.findByIdAndClient(anyLong(), anyLong()))
+                .willReturn(Optional.of(new Memo(null, MemoType.CALL, null)));
+
+        // when
+        memoService.delete(userId, clientId, memoId);
+
+        // then
+        verify(memoRepository).delete(any());
+    }
+
+    @Test
+    @DisplayName("메모 조회 실패로 삭제에 실패한다.")
+    void deleteFail() {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        Long memoId = 1L;
+        given(clientRepository.findByIdAndUser(anyLong(), anyLong()))
+                .willReturn(Optional.of(new Client("a", "a", null, null)));
+        given(memoRepository.findByIdAndClient(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> memoService.delete(userId, clientId, memoId))
+                .isInstanceOf(MemoNotFoundException.class);
     }
 }

--- a/src/test/java/com/map/gaja/memo/application/MemoServiceTest.java
+++ b/src/test/java/com/map/gaja/memo/application/MemoServiceTest.java
@@ -1,0 +1,67 @@
+package com.map.gaja.memo.application;
+
+import com.map.gaja.client.domain.exception.ClientNotFoundException;
+import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.client.infrastructure.repository.ClientRepository;
+import com.map.gaja.memo.infrastructure.MemoRepository;
+import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemoServiceTest {
+    @Mock
+    ClientRepository clientRepository;
+
+    @Mock
+    MemoRepository memoRepository;
+
+    @InjectMocks
+    MemoService memoService;
+
+    @Test
+    @DisplayName("메모 생성에 성공한다.")
+    void createSuccess() {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        MemoCreateRequest request = new MemoCreateRequest("message", "CALL");
+        given(clientRepository.findByIdAndUser(anyLong(), anyLong()))
+                .willReturn(Optional.of(new Client("a", "a", null, null)));
+
+        // when
+        memoService.create(userId, clientId, request);
+
+        // when, then
+        verify(memoRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("Client 조회 실패로 메모 생성에 실패한다.")
+    void createFail() {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        MemoCreateRequest request = new MemoCreateRequest("message", "CALL");
+        given(clientRepository.findByIdAndUser(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> memoService.create(userId, clientId, request))
+                .isInstanceOf(ClientNotFoundException.class);
+
+
+    }
+}

--- a/src/test/java/com/map/gaja/memo/application/MemoServiceTest.java
+++ b/src/test/java/com/map/gaja/memo/application/MemoServiceTest.java
@@ -74,47 +74,11 @@ class MemoServiceTest {
     }
 
     @Test
-    @DisplayName("메모 삭제에 성공한다.")
-    void deleteSuccess() {
-        // given
-        Long userId = 1L;
-        Long clientId = 1L;
-        Long memoId = 1L;
-        given(clientRepository.findByIdAndUser(anyLong(), anyLong()))
-                .willReturn(Optional.of(new Client("a", "a", null, null)));
-        given(memoRepository.findByIdAndClient(anyLong(), anyLong()))
-                .willReturn(Optional.of(new Memo(null, MemoType.CALL, null)));
-
-        // when
-        memoService.delete(userId, clientId, memoId);
-
-        // then
-        verify(memoRepository).delete(any());
-    }
-
-    @Test
-    @DisplayName("메모 조회 실패로 삭제에 실패한다.")
-    void deleteFail() {
-        // given
-        Long userId = 1L;
-        Long clientId = 1L;
-        Long memoId = 1L;
-        given(clientRepository.findByIdAndUser(anyLong(), anyLong()))
-                .willReturn(Optional.of(new Client("a", "a", null, null)));
-        given(memoRepository.findByIdAndClient(anyLong(), anyLong()))
-                .willReturn(Optional.empty());
-
-        // when, then
-        assertThatThrownBy(() -> memoService.delete(userId, clientId, memoId))
-                .isInstanceOf(MemoNotFoundException.class);
-    }
-
-    @Test
     @DisplayName("메모를 최신순으로 조회한다.")
     void findPageByClientId() {
         // given
-        Memo memo = new Memo(null, MemoType.CALL, null);
-        Memo memo2 = new Memo(null, MemoType.NAVIGATION, null);
+        Memo memo = new Memo(null, MemoType.CALL, null, null);
+        Memo memo2 = new Memo(null, MemoType.NAVIGATION, null, null);
         List<Memo> memos = List.of(memo, memo2);
         Long userId = 1L;
         Long clientId = 1L;

--- a/src/test/java/com/map/gaja/memo/domain/model/MemoTypeTest.java
+++ b/src/test/java/com/map/gaja/memo/domain/model/MemoTypeTest.java
@@ -1,0 +1,40 @@
+package com.map.gaja.memo.domain.model;
+
+import com.map.gaja.memo.domain.exception.MemoTypeNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MemoTypeTest {
+    @Test
+    @DisplayName("MemoType CALL을 가져온다.")
+    void getCallMemoType() {
+        assertThat(MemoType.CALL)
+                .isEqualTo(MemoType.from("CALL"));
+    }
+
+    @Test
+    @DisplayName("MemoType MESSAGE을 가져온다.")
+    void getMessageMemoType() {
+        assertThat(MemoType.MESSAGE)
+                .isEqualTo(MemoType.from("MESSAGE"));
+    }
+
+    @Test
+    @DisplayName("MemoType NAVIGATION을 가져온다.")
+    void getNavigationMemoType() {
+        assertThat(MemoType.NAVIGATION)
+                .isEqualTo(MemoType.from("NAVIGATION"));
+    }
+
+    @Test
+    @DisplayName("MemoType을 가져오는데 실패한다")
+    void getMemoTypeFail() {
+        assertThatThrownBy(() -> MemoType.from("WOWOW"))
+                .isInstanceOf(MemoTypeNotFoundException.class);
+    }
+
+
+}

--- a/src/test/java/com/map/gaja/memo/infrastructure/MemoRepositoryTest.java
+++ b/src/test/java/com/map/gaja/memo/infrastructure/MemoRepositoryTest.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @SpringBootTest
 @Transactional
@@ -42,7 +43,7 @@ class MemoRepositoryTest {
         em.flush();
         em.clear();
 
-        Memo memo = new Memo(null, MemoType.CALL, client);
+        Memo memo = new Memo(null, MemoType.CALL, client, user);
         memoRepository.save(memo);
 
         // when, then
@@ -63,7 +64,7 @@ class MemoRepositoryTest {
         em.flush();
         em.clear();
 
-        Memo memo = new Memo(null, MemoType.CALL, client);
+        Memo memo = new Memo(null, MemoType.CALL, client, user);
         memoRepository.save(memo);
 
         // when, then
@@ -78,8 +79,8 @@ class MemoRepositoryTest {
         User user = TestEntityCreator.createUser("test@gmail.com");
         Group group = TestEntityCreator.createGroup(user, "group");
         Client client = TestEntityCreator.createClient(0, group, user);
-        Memo memo = new Memo(null, MemoType.CALL, client);
-        Memo memo2 = new Memo(null, MemoType.NAVIGATION, client);
+        Memo memo = new Memo(null, MemoType.CALL, client, user);
+        Memo memo2 = new Memo(null, MemoType.NAVIGATION, client, user);
         em.persist(user);
         em.persist(group);
         em.persist(client);
@@ -95,5 +96,23 @@ class MemoRepositoryTest {
         assertThat(memos.getSize()).isEqualTo(2);
         assertThat(memos.getContent().get(0)).isEqualTo(memo2);
         assertThat(memos.getContent().get(1)).isEqualTo(memo);
+    }
+
+    @Test
+    @DisplayName("메모를 삭제한다.")
+    void deleteByIdAndUser() {
+        // given
+        User user = TestEntityCreator.createUser("test@gmail.com");
+        Group group = TestEntityCreator.createGroup(user, "group");
+        Client client = TestEntityCreator.createClient(0, group, user);
+        Memo memo = new Memo(null, MemoType.CALL, client, user);
+        em.persist(user);
+        em.persist(group);
+        em.persist(client);
+        em.persist(memo);
+        em.flush();
+
+        // when, then
+        assertDoesNotThrow(() -> memoRepository.deleteByIdAndUser(memo.getId(), user.getId()));
     }
 }

--- a/src/test/java/com/map/gaja/memo/infrastructure/MemoRepositoryTest.java
+++ b/src/test/java/com/map/gaja/memo/infrastructure/MemoRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.map.gaja.memo.infrastructure;
+
+import com.map.gaja.TestEntityCreator;
+import com.map.gaja.client.domain.model.Client;
+import com.map.gaja.group.domain.model.Group;
+import com.map.gaja.memo.domain.model.Memo;
+import com.map.gaja.memo.domain.model.MemoType;
+import com.map.gaja.user.domain.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class MemoRepositoryTest {
+    @Autowired
+    MemoRepository memoRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @DisplayName("User가 가진 Memo를 조회한다.")
+    void findByIdAndClientSuccess() {
+        // given
+        User user = TestEntityCreator.createUser("test@gmail.com");
+        Group group = TestEntityCreator.createGroup(user, "group");
+        Client client = TestEntityCreator.createClient(0, group, user);
+        em.persist(user);
+        em.persist(group);
+        em.persist(client);
+        em.flush();
+        em.clear();
+
+        Memo memo = new Memo(null, MemoType.CALL, client);
+        memoRepository.save(memo);
+
+        // when, then
+        assertThat(memoRepository.findByIdAndClient(memo.getId(), client.getId()).get())
+                .isNotNull();
+    }
+
+    @Test
+    @DisplayName("User가 가진 Memo의 조회 실패한다.")
+    void findByIdAndClientFail() {
+        // given
+        User user = TestEntityCreator.createUser("test@gmail.com");
+        Group group = TestEntityCreator.createGroup(user, "group");
+        Client client = TestEntityCreator.createClient(0, group, user);
+        em.persist(user);
+        em.persist(group);
+        em.persist(client);
+        em.flush();
+        em.clear();
+
+        Memo memo = new Memo(null, MemoType.CALL, client);
+        memoRepository.save(memo);
+
+        // when, then
+        assertThat(memoRepository.findByIdAndClient(memo.getId(), user.getId() + 1).isEmpty())
+                .isTrue();
+    }
+}

--- a/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
+++ b/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
@@ -44,7 +44,7 @@ class MemoControllerTest {
         MemoCreateRequest request = new MemoCreateRequest("gajamap", "MESSAGE");
 
         // when, then
-        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+        mvc.perform(post("/api/memo/client/{clientId}", clientId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .with(csrf())
@@ -65,7 +65,7 @@ class MemoControllerTest {
         MemoCreateRequest request = new MemoCreateRequest(message.toString(), "MESSAGE");
 
         // when, then
-        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+        mvc.perform(post("/api/memo/client/{clientId}", clientId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .with(csrf())
@@ -86,7 +86,7 @@ class MemoControllerTest {
         MemoCreateRequest request = new MemoCreateRequest(null, memoType.toString());
 
         // when, then
-        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+        mvc.perform(post("/api/memo/client/{clientId}", clientId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .with(csrf())
@@ -103,7 +103,7 @@ class MemoControllerTest {
         MemoCreateRequest request = new MemoCreateRequest(null, null);
 
         // when, then
-        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+        mvc.perform(post("/api/memo/client/{clientId}", clientId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .with(csrf())

--- a/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
+++ b/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
@@ -119,10 +119,9 @@ class MemoControllerTest {
         // given
         Long userId = 1L;
         Long memoId = 1L;
-        Long clientId = 1L;
 
         // when, then
-        mvc.perform(MockMvcRequestBuilders.delete("/api/memo/{memoId}/client/{clientId}", memoId, clientId)
+        mvc.perform(MockMvcRequestBuilders.delete("/api/memo/{memoId}", memoId)
                 .with(csrf())
                 .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
         ).andExpect(status().isOk());
@@ -136,7 +135,7 @@ class MemoControllerTest {
         Long clientId = 1L;
 
         // when, then
-        mvc.perform(MockMvcRequestBuilders.get("/api/memo/client/{clientId}?page=0&size=10", clientId)
+        mvc.perform(MockMvcRequestBuilders.get("/api/memo/client/{clientId}?page=0", clientId)
                 .with(csrf())
                 .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
         ).andExpect(status().isOk());

--- a/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
+++ b/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
@@ -5,9 +5,10 @@ import com.map.gaja.global.authentication.AuthenticationRepository;
 import com.map.gaja.global.authentication.PrincipalDetails;
 import com.map.gaja.memo.application.MemoService;
 import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -15,6 +16,7 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,7 +39,7 @@ class MemoControllerTest {
 
     @Test
     @DisplayName("메모를 생성에 성공하면 201을 반환한다.")
-    void createTest() throws Exception {
+    void create() throws Exception {
         // given
         Long userId = 1L;
         Long clientId = 1L;
@@ -111,4 +113,32 @@ class MemoControllerTest {
         ).andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("메모를 삭제하면 200을 반환한다.")
+    void delete() throws Exception {
+        // given
+        Long userId = 1L;
+        Long memoId = 1L;
+        Long clientId = 1L;
+
+        // when, then
+        mvc.perform(MockMvcRequestBuilders.delete("/api/memo/{memoId}/client/{clientId}", memoId, clientId)
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("메모를 조회하면 200반환한다.")
+    void read() throws Exception {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+
+        // when, then
+        mvc.perform(MockMvcRequestBuilders.get("/api/memo/client/{clientId}?page=0&size=10", clientId)
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
+        ).andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
+++ b/src/test/java/com/map/gaja/memo/presentation/api/MemoControllerTest.java
@@ -1,0 +1,114 @@
+package com.map.gaja.memo.presentation.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.map.gaja.global.authentication.AuthenticationRepository;
+import com.map.gaja.global.authentication.PrincipalDetails;
+import com.map.gaja.memo.application.MemoService;
+import com.map.gaja.memo.presentation.dto.request.MemoCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MemoController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class MemoControllerTest {
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    MemoService memoService;
+
+    @MockBean
+    AuthenticationRepository authenticationRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("메모를 생성에 성공하면 201을 반환한다.")
+    void createTest() throws Exception {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        MemoCreateRequest request = new MemoCreateRequest("gajamap", "MESSAGE");
+
+        // when, then
+        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
+        ).andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("메모 메시지가 100자를 넘기면 400을 반환한다.")
+    void memoMessage100Fail() throws Exception {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        StringBuilder message = new StringBuilder();
+        for (int i = 1; i <= 101; i++) {
+            message.append(i);
+        }
+        MemoCreateRequest request = new MemoCreateRequest(message.toString(), "MESSAGE");
+
+        // when, then
+        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("메모 타입이 15자를 넘기면 400을 반환한다.")
+    void memoType15Fail() throws Exception {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        StringBuilder memoType = new StringBuilder();
+        for (int i = 1; i <= 16; i++) {
+            memoType.append(i);
+        }
+        MemoCreateRequest request = new MemoCreateRequest(null, memoType.toString());
+
+        // when, then
+        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("메모 타입이 null이면 400을 반환한다.")
+    void memoTypeNullFail() throws Exception {
+        // given
+        Long userId = 1L;
+        Long clientId = 1L;
+        MemoCreateRequest request = new MemoCreateRequest(null, null);
+
+        // when, then
+        mvc.perform(post("/api/memo/client/{clientId}/message", clientId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user(new PrincipalDetails(userId, "test@gmail.com", "FREE")))
+        ).andExpect(status().isBadRequest());
+    }
+
+}


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #427 

<!--
 전달할 내용
-->
## comment
- 메모 조회, 생성, 삭제만 했고 나중에 상세 정보 페이지에서 Client정보 뿐만 아니라 메모도 함께 줘야될 것 같음. 이 부분은 메모 UI 먼저 생각해보고 안드로이드에서 개발이 다 되었을 때 해도 괜찮을 것 같음.
- 메모를 10개씩 페이징 조회했는데 사용자들이 페이징 조회 size를 인위적으로 변경할 수 있어서 resolver 구현해서 막았음.
- Client를 간단하게 설명할 수 있는 description 필드가 있으면 좋을 것 같음
- Memo에 userId 필드 추가 어때? 조회할 때 User와 Client를 join하는데 Memo에 userId 필드가 추가되면 조회할 때 User를 join할 필요 없어짐.
- 메모를 영구적으로 저장하는 것이 아닌 스케줄링으로 6개월? 1년 단위로 삭제 어떰?

위 내용들은 UI 디자인도 생각해야 되니깐 디코로 얘기해도 괜찮

<!--
 참고한 사이트
-->
## References
- https://www.blog.ecsimsw.com/entry/Spring-MVC-Pageable%EC%9D%98-Max-page-size-%EC%A0%9C%ED%95%9C%ED%95%98%EA%B8%B0