### PR TITLE
자동 로그인 응답 속도 개선

### DIFF
--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -273,4 +273,30 @@ public class ClientQueryRepository {
     private static BooleanExpression isClientInGroup(long groupId) {
         return client.group.id.eq(groupId);
     }
+
+    public List<ClientOverviewResponse> findWholeGroupClients(Long userId, Integer limit) {
+        List<ClientOverviewResponse> result = query
+                .select(
+                        Projections.constructor(ClientOverviewResponse.class,
+                                client.id,
+                                Projections.constructor(GroupInfoDto.class, client.group.id, client.group.name),
+                                client.name,
+                                client.phoneNumber,
+                                Projections.constructor(AddressDto.class, client.address.address, client.address.detail),
+                                Projections.constructor(LocationDto.class, client.location.location),
+                                Projections.constructor(StoredFileDto.class, client.clientImage.savedPath, client.clientImage.originalName),
+                                client.createdAt
+                        )
+                )
+                .from(client)
+                .leftJoin(client.clientImage, clientImage)
+                .join(client.group, group)
+                .where(client.user.id.eq(userId).and(client.group.user.id.eq(userId)))
+                .orderBy(client.id.desc())
+                .limit(limit)
+                .fetch();
+
+        return result;
+    }
+
 }

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -299,4 +299,28 @@ public class ClientQueryRepository {
         return result;
     }
 
+    public List<ClientOverviewResponse> findRecentGroupClients(Long groupId, Integer limit) {
+        List<ClientOverviewResponse> result = query
+                .select(
+                        Projections.constructor(ClientOverviewResponse.class,
+                                client.id,
+                                Projections.constructor(GroupInfoDto.class, client.group.id, client.group.name),
+                                client.name,
+                                client.phoneNumber,
+                                Projections.constructor(AddressDto.class, client.address.address, client.address.detail),
+                                Projections.constructor(LocationDto.class, client.location.location),
+                                Projections.constructor(StoredFileDto.class, client.clientImage.savedPath, client.clientImage.originalName),
+                                client.createdAt
+                        )
+                )
+                .from(client)
+                .leftJoin(client.clientImage, clientImage)
+                .join(client.group, group)
+                .where(client.group.id.eq(groupId))
+                .orderBy(client.id.desc())
+                .limit(limit)
+                .fetch();
+
+        return result;
+    }
 }

--- a/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
+++ b/src/main/java/com/map/gaja/client/infrastructure/repository/ClientQueryRepository.java
@@ -291,7 +291,7 @@ public class ClientQueryRepository {
                 .from(client)
                 .leftJoin(client.clientImage, clientImage)
                 .join(client.group, group)
-                .where(client.user.id.eq(userId).and(client.group.user.id.eq(userId)))
+                .where(client.user.id.eq(userId))
                 .orderBy(client.id.desc())
                 .limit(limit)
                 .fetch();
@@ -299,7 +299,7 @@ public class ClientQueryRepository {
         return result;
     }
 
-    public List<ClientOverviewResponse> findRecentGroupClients(Long groupId, Integer limit) {
+    public List<ClientOverviewResponse> findRecentGroupClients(Long groupId) {
         List<ClientOverviewResponse> result = query
                 .select(
                         Projections.constructor(ClientOverviewResponse.class,
@@ -318,7 +318,6 @@ public class ClientQueryRepository {
                 .join(client.group, group)
                 .where(client.group.id.eq(groupId))
                 .orderBy(client.id.desc())
-                .limit(limit)
                 .fetch();
 
         return result;

--- a/src/main/java/com/map/gaja/user/application/AutoLoginProcessor.java
+++ b/src/main/java/com/map/gaja/user/application/AutoLoginProcessor.java
@@ -46,7 +46,7 @@ public class AutoLoginProcessor {
             return new ClientListResponse(clientList);
         }
 
-        List<ClientOverviewResponse> clientList = clientQueryRepository.findRecentGroupClients(user.getReferenceGroupId(), user.getAuthority().getClientLimitCount());
+        List<ClientOverviewResponse> clientList = clientQueryRepository.findRecentGroupClients(user.getReferenceGroupId());
         return new ClientListResponse(clientList);
 
     }

--- a/src/main/java/com/map/gaja/user/presentation/api/UserController.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/UserController.java
@@ -49,8 +49,8 @@ public class UserController implements UserApiSpecification {
 
     @Override
     @GetMapping("/auto-login")
-    public ResponseEntity<AutoLoginResponse> autoLogin(@AuthenticationPrincipal(expression = "name") String email) {
-        AutoLoginResponse response = autoLoginProcessor.process(email);
+    public ResponseEntity<AutoLoginResponse> autoLogin(@AuthenticationPrincipal(expression = "userId") Long userId) {
+        AutoLoginResponse response = autoLoginProcessor.process(userId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
+++ b/src/main/java/com/map/gaja/user/presentation/api/specification/UserApiSpecification.java
@@ -53,7 +53,7 @@ public interface UserApiSpecification {
 
     @Operation(summary = "앱 자동로그인 처리(앱 실행할 때마다 요청)",
             parameters = {
-                    @Parameter(name = "JSESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
+                    @Parameter(name = "SESSIONID", description = "세션 ID", in = ParameterIn.HEADER),
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "사용자가 최근에 참조한 그룹정보와, 그룹에 속한 고객들 응답"),
@@ -61,6 +61,6 @@ public interface UserApiSpecification {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다.", content = @Content(schema = @Schema(implementation = ExceptionDto.class)))
             }
     )
-    ResponseEntity<AutoLoginResponse> autoLogin(@Parameter(hidden = true) String email);
+    ResponseEntity<AutoLoginResponse> autoLogin(@Parameter(hidden = true) Long userId);
 
 }

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
@@ -180,7 +180,7 @@ class ClientQueryNativeRepositoryTest {
     @DisplayName("사용자가 최근에 참조한 특정 그룹에 속해 있는 Client를 조회한다")
     void findRecentGroupClients() {
         // when
-        List<ClientOverviewResponse> result = clientQueryRepository.findRecentGroupClients(group1.getId(), user.getAuthority().getClientLimitCount());
+        List<ClientOverviewResponse> result = clientQueryRepository.findRecentGroupClients(group1.getId());
 
         // then
         assertThat(result.stream()

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
@@ -176,4 +176,16 @@ class ClientQueryNativeRepositoryTest {
                 .isEqualTo(group2ClientList.size());
     }
 
+    @Test
+    @DisplayName("사용자가 최근에 참조한 특정 그룹에 속해 있는 Client를 조회한다")
+    void findRecentGroupClients() {
+        // when
+        List<ClientOverviewResponse> result = clientQueryRepository.findRecentGroupClients(group1.getId(), user.getAuthority().getClientLimitCount());
+
+        // then
+        assertThat(result.stream()
+                .filter(c -> c.getGroupInfo().getGroupId().equals(group1.getId()))
+                .count())
+                .isEqualTo(group1ClientList.size());
+    }
 }

--- a/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
+++ b/src/test/java/com/map/gaja/client/infrastructure/repository/ClientQueryNativeRepositoryTest.java
@@ -27,7 +27,8 @@ class ClientQueryNativeRepositoryTest {
     @Autowired
     ClientQueryRepository clientQueryRepository;
 
-    @Autowired ClientRepository clientRepository;
+    @Autowired
+    ClientRepository clientRepository;
 
     @Autowired
     EntityManager em;
@@ -78,7 +79,7 @@ class ClientQueryNativeRepositoryTest {
         List<Long> groupIdList = new ArrayList<>();
         groupIdList.add(groupId);
 
-        List<ClientOverviewResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request,nameKeyword);
+        List<ClientOverviewResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request, nameKeyword);
 
         assertThat(result.size()).isEqualTo(group2ClientList.size());
         double beforeDistance = -1;
@@ -105,7 +106,7 @@ class ClientQueryNativeRepositoryTest {
         groupIdList.add(groupId1);
         groupIdList.add(groupId2);
 
-        List<ClientOverviewResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request,nameKeyword);
+        List<ClientOverviewResponse> result = clientQueryRepository.findClientByConditions(groupIdList, request, nameKeyword);
 
         assertThat(result.size()).isEqualTo(group1ClientList.size() + group2ClientList.size());
         result.forEach((client) -> {
@@ -154,4 +155,25 @@ class ClientQueryNativeRepositoryTest {
             assertThat(client.getClientName()).contains(nameCond);
         });
     }
+
+    @Test
+    @DisplayName("사용자가 최근에 참조한 전체 그룹에 속해 있는 Client를 조회한다")
+    void findWholeGroupClients() {
+        // when
+        List<ClientOverviewResponse> result = clientQueryRepository.findWholeGroupClients(user.getId(), user.getAuthority().getClientLimitCount());
+
+        // then
+        assertThat(result.size()).isEqualTo(group1ClientList.size() + group2ClientList.size());
+
+        assertThat(result.stream()
+                .filter(c -> c.getGroupInfo().getGroupId().equals(group1.getId()))
+                .count())
+                .isEqualTo(group1ClientList.size());
+
+        assertThat(result.stream()
+                .filter(c -> c.getGroupInfo().getGroupId().equals(group2.getId()))
+                .count())
+                .isEqualTo(group2ClientList.size());
+    }
+
 }

--- a/src/test/java/com/map/gaja/user/application/AutoLoginProcessorTest.java
+++ b/src/test/java/com/map/gaja/user/application/AutoLoginProcessorTest.java
@@ -95,14 +95,14 @@ class AutoLoginProcessorTest {
                 .willReturn(Optional.of(user));
         given(groupRepository.findGroupInfoById(anyLong()))
                 .willReturn(Optional.of(groupInfo));
-        given(clientQueryRepository.findRecentGroupClients(anyLong(), anyInt()))
+        given(clientQueryRepository.findRecentGroupClients(anyLong()))
                 .willReturn(clients);
 
         // when
         autoLoginProcessor.process(userId);
 
         // then
-        verify(clientQueryRepository).findRecentGroupClients(user.getReferenceGroupId(), user.getAuthority().getClientLimitCount());
+        verify(clientQueryRepository).findRecentGroupClients(user.getReferenceGroupId());
         verify(groupRepository).findGroupInfoById(user.getReferenceGroupId());
     }
 }

--- a/src/test/java/com/map/gaja/user/application/AutoLoginProcessorTest.java
+++ b/src/test/java/com/map/gaja/user/application/AutoLoginProcessorTest.java
@@ -1,11 +1,11 @@
 package com.map.gaja.user.application;
 
-import com.map.gaja.client.domain.model.Client;
 import com.map.gaja.client.infrastructure.repository.ClientQueryRepository;
 import com.map.gaja.client.infrastructure.s3.S3UrlGenerator;
 import com.map.gaja.client.presentation.dto.response.ClientOverviewResponse;
 import com.map.gaja.group.infrastructure.GroupRepository;
 import com.map.gaja.group.presentation.dto.response.GroupInfo;
+import com.map.gaja.user.domain.model.Authority;
 import com.map.gaja.user.domain.model.User;
 import com.map.gaja.user.infrastructure.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -44,31 +45,35 @@ class AutoLoginProcessorTest {
     @DisplayName("사용자가 최근에 참조한 전체 그룹 조회")
     void findWholeGroup() {
         // given
-        String email = "test@gmail.com";
-        User user = new User(email);
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .lastLoginDate(LocalDateTime.now())
+                .authority(Authority.FREE)
+                .build();
         List<ClientOverviewResponse> clientList = new ArrayList<>();
 
-        given(clientQueryRepository.findActiveClientByEmail(email, null))
-                .willReturn(clientList);
-
-        given(userRepository.findByEmailAndActive(email))
+        given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
 
+        given(clientQueryRepository.findWholeGroupClients(anyLong(), anyInt()))
+                .willReturn(clientList);
+
         // when
-        autoLoginProcessor.process(email);
+        autoLoginProcessor.process(userId);
 
         // then
-        verify(clientQueryRepository).findActiveClientByEmail(email, null);
+        verify(clientQueryRepository).findWholeGroupClients(userId, user.getAuthority().getClientLimitCount());
     }
 
     @Test
     @DisplayName("사용자가 최근에 참조한 특정 그룹 조회")
     void findGroup() {
         // given
-        String email = "test@gmail.com";
-        User user = new User(email);
+        Long userId = 1L;
+        User user = new User("test@gmail.com");
         user.accessGroup(1L);
-        List<Client> clients = new ArrayList<>();
+        List<ClientOverviewResponse> clients = new ArrayList<>();
         GroupInfo groupInfo = new GroupInfo() {
             @Override
             public Long getGroupId() {
@@ -86,18 +91,18 @@ class AutoLoginProcessorTest {
             }
         };
 
-        given(userRepository.findByEmailAndActive(email))
+        given(userRepository.findById(anyLong()))
                 .willReturn(Optional.of(user));
-        given(groupRepository.findGroupInfoById(user.getReferenceGroupId()))
+        given(groupRepository.findGroupInfoById(anyLong()))
                 .willReturn(Optional.of(groupInfo));
-        given(clientQueryRepository.findByGroup_Id(user.getReferenceGroupId(), null))
+        given(clientQueryRepository.findRecentGroupClients(anyLong(), anyInt()))
                 .willReturn(clients);
 
         // when
-        autoLoginProcessor.process(email);
+        autoLoginProcessor.process(userId);
 
         // then
-        verify(clientQueryRepository).findByGroup_Id(user.getReferenceGroupId(), null);
+        verify(clientQueryRepository).findRecentGroupClients(user.getReferenceGroupId(), user.getAuthority().getClientLimitCount());
         verify(groupRepository).findGroupInfoById(user.getReferenceGroupId());
     }
 }


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #437 

<!--
 전달할 내용
-->
## comment
아래와 같이 ORDER BY sort 과정 없애려고 복합 인덱스로 생성함. 안 그러면 DB내에서 sort 과정을 거치는데 레코드 수가 증가함에 따라 속도가 저하됨
- CREATE INDEX client_group ON client(group_id, client_id);
- CREATE INDEX client_user ON client(user_id, client_id);

User(100), Group(1000), Client(1_000_000) 일 때 전체그룹(user_id = 50)와 특정그룹(group_id=500) 테스트 결과
**전체그룹:** 380ms -> 3.5ms
**특정그룹:** 315ms -> 3.8ms

**더 개선할 점**
- 비동기 이벤트 시 스레드 생성과 삭제 오버헤드가 있다고 해서 비동기 스레드 풀 추가 후 속도 비교해서 괜찮다면 개선할 예정

<!--
 참고한 사이트
-->
## References
- https://pganalyze.com/docs/explain
- https://burning-dba.tistory.com/79