### PR TITLE
feat: ERROR 로그 슬랙으로 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,9 @@ dependencies {
 	implementation 'io.github.resilience4j:resilience4j-circuitbreaker:1.7.1'
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
 
+	// slack
+	implementation 'com.github.maricn:logback-slack-appender:1.6.1'
+
 	compileOnly 'org.projectlombok:lombok'
 //	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'org.postgresql:postgresql' // DB 변경

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration status="info">
-
     <!-- 날짜 / 스레드명 / 로깅레벨 / 로그 최대 글자수(36) / 메소드명:줄 / 로그메시지 -->
-    <property name="LOG_PATTERN_COLOR" value = "%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%-5level) %cyan(%logger{36}.%method:%line) - %yellow(%msg%n)"></property>
-    <property name="LOG_PATTERN_WITHOUT_COLOR" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%method:%line - %msg%n" />
-    <property name="TIME_CHECK_LOG_PATTERN_COLOR" value = "%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %yellow(%msg%n)"></property>
+    <property name="LOG_PATTERN_COLOR"
+              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %highlight(%-5level) %cyan(%logger{36}.%method:%line) - %yellow(%msg%n)"></property>
+    <property name="LOG_PATTERN_WITHOUT_COLOR"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36}.%method:%line - %msg%n"/>
+    <property name="TIME_CHECK_LOG_PATTERN_COLOR"
+              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %yellow(%msg%n)"></property>
 
     <!-- appender는 로그를 어떤 방식으로 넣을 것인지 설정 -->
     <appender name="TIME_CHECK" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -35,9 +37,11 @@
     <appender name="SERVICE_INFO" class="ch.qos.logback.core.FileAppender">
         <append>true</append>
         <file>logs/ServiceInfo.log</file>
+
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>DENY</onMatch>
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
         </filter>
 
         <encoder>
@@ -45,39 +49,37 @@
         </encoder>
     </appender>
 
-    <appender name="SERVICE_ERROR" class="ch.qos.logback.core.FileAppender">
-        <append>true</append>
-        <file>logs/ServiceError.log</file>
+    <!-- slack -->
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-url"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
+        </layout>
+        <username>server-error</username>
+        <queueSize>3</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>
-        <encoder>
-            <pattern>${LOG_PATTERN_COLOR}</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="APPLICATION" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${LOG_PATTERN_COLOR}</pattern>
-        </encoder>
     </appender>
 
 
-    <!-- 분리된 로그 파일 로그 설정 -->
-    <logger name="com.map.gaja.global.schedule.DeletionTask" level="info" additivity="false">
-        <appender-ref ref="DeletionTask" /> <!-- 삭제 스케줄링 -->
+    <!-- 로그 지정 -->
+    <logger name="com.map.gaja.global.schedule.DeletionTask" level="INFO" additivity="false">
+        <appender-ref ref="DeletionTask"/> <!-- 삭제 스케줄링 -->
     </logger>
 
-    <logger name="com.map.gaja.global.log.TimeCheckLogAspect" level="info" additivity="false">
+    <logger name="com.map.gaja.global.log.TimeCheckLogAspect" level="INFO" additivity="false">
         <appender-ref ref="TIME_CHECK"></appender-ref> <!-- 로직 시간 측정 -->
     </logger>
 
-    <logger name="com.map.gaja" level="info" additivity="false">
-        <appender-ref ref="SERVICE_INFO" /> <!-- 서비스 운영 Info 로그 -->
-        <appender-ref ref="SERVICE_ERROR" /> <!-- 서비스 운영 Error 로그 -->
-    </logger>
-
-    <root level="info">
-        <appender-ref ref="APPLICATION" /> <!-- 프로젝트 실행 로그 -->
+    <root level="INFO">
+        <appender-ref ref="SERVICE_INFO"></appender-ref>
+        <appender-ref ref="ASYNC_SLACK"></appender-ref>
     </root>
 </configuration>


### PR DESCRIPTION
<!--
#이슈번호 입력
-->
## Issue
- #439 

<!--
 전달할 내용
-->
## comment
- ERROR 로그 파일은 지우고 슬랙으로 전송하도록 변경함.  슬랙 전송은 AsyncAppender 비동기로 설정함. yml 파일에 아래와 같이 설정해주면 연동 완료이고 url은 카톡으로 줄게 그리고 알림을 받기위해 슬랙 앱을 설치하면 슬랙도 초대해드림
```
logging:
  slack:
    webhook-url: ****
```
- TimeCheck.log 속도 측정 로그가 매 요청마다 파일에 기록되는데 모니터링을 구축했으니깐 더 이상 필요한가 싶음. 그리고 저게 동기식이라서 응답 속도 저하의 원인이 됨. 만약 이 부분이 필요하다면 비동기를 고려하면 좋을듯

<!--
 참고한 사이트
-->
## References
- https://logback.qos.ch/manual/appenders.html
- https://skagh.tistory.com/37